### PR TITLE
Allow err params in callbacks and support objects in Client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,9 +9,17 @@ import {Tag} from './tag';
 import {Segment} from './segment';
 
 export class Client {
-  constructor(appId, appApiKey) {
-    this.appId = appId;
-    this.appApiKey = appApiKey;
+  constructor(...args) {
+    if (args.length === 2) {
+      this.appId = args[0];
+      this.appApiKey = args[1];
+    } else if (args.length === 1) {
+      this.appId = args[0].appId;
+      this.appApiKey = args[0].appApiKey;
+    }
+    if (!this.appId || !this.appApiKey) {
+      throw new Error('Could not construct a client with those parameters');
+    }
     this.users = new User(this);
     this.events = new Event(this);
     this.companies = new Company(this);
@@ -36,7 +44,7 @@ export class Client {
     .send(data)
     .header('Accept', 'application/json')
     .header('User-Agent', 'intercom-node-client/0.1.2')
-    .end(r => f(r));
+    .end(r => this.callback(f, r));
   }
   get(endpoint, data, f) {
     unirest.get(`https://api.intercom.io${endpoint}`)
@@ -45,7 +53,7 @@ export class Client {
     .query(data)
     .header('Accept', 'application/json')
     .header('User-Agent', 'intercom-node-client/0.1.2')
-    .end(r => f(r));
+    .end(r => this.callback(f, r));
   }
   nextPage(paginationObject, f) {
     unirest.get(paginationObject.next)
@@ -53,7 +61,7 @@ export class Client {
     .type('json')
     .header('Accept', 'application/json')
     .header('User-Agent', 'intercom-node-client/0.1.2')
-    .end(r => f(r));
+    .end(r => this.callback(f, r));
   }
   delete(endpoint, data, f) {
     unirest.delete(`https://api.intercom.io${endpoint}`)
@@ -62,6 +70,18 @@ export class Client {
     .query(data)
     .header('Accept', 'application/json')
     .header('User-Agent', 'intercom-node-client/0.1.2')
-    .end(r => f(r));
+    .end(r => this.callback(f, r));
+  }
+  callback(f, data) {
+    if (f.length >= 2) {
+      let hasErrors = data.body && data.body.type === 'error.list';
+      if (hasErrors) {
+        f(data, null);
+      } else {
+        f(null, data);
+      }
+    } else {
+      f(data);
+    }
   }
 }

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import {Client} from '../lib';
+
+describe('users', function () {
+  it('should callback with errors', function (done) {
+    let callback = function (err, d) {
+      assert.equal('error.list', err.body.type);
+      assert.equal(null, d);
+      done();
+    };
+    let client = new Client('foo', 'bar');
+    client.callback(callback, { body: { type: 'error.list' }});
+  });
+  it('should construct with two fields', function () {
+    let client = new Client('foo', 'bar');
+    assert.equal('foo', client.appId);
+    assert.equal('bar', client.appApiKey);
+  });
+  it('should construct with an object', function () {
+    let client = new Client({ appId: 'foo', appApiKey: 'bar' });
+    assert.equal('foo', client.appId);
+    assert.equal('bar', client.appApiKey);
+  });
+  it('should throw if no credentials found', function () {
+    assert.throws(function () {
+      let client = new Client('baz');
+      console.log(client.appId);
+    }, /Could not construct a client with those parameters/);
+  });
+});


### PR DESCRIPTION
If the callback has 2-arity, we assume the first param is `err` and use it when the API returns an `error.list`. This allows for idiomatic callback handling like:


```node
client.users.list(function(err, d) { ... });
```

Additionally this pr adds support for objects in client construction:

```node
var client = new Client({ appId: 'foo', appApiKey: 'bar' });
```

fixes https://github.com/intercom/intercom-node/issues/15