### PR TITLE
Promises support

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -3,6 +3,6 @@ export class Admin {
     this.client = client;
   }
   list(f) {
-    this.client.get('/admins', {}, f);
+    return this.client.get('/admins', {}, f);
   }
 }

--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -21,6 +21,6 @@ export class Bulk {
         });
       }
     });
-    this.client.post(url, bulkParams, f);
+    return this.client.post(url, bulkParams, f);
   }
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -34,6 +34,28 @@ export class Client {
     this.messages = new Message(this);
     this.conversations = new Conversation(this);
     this.notes = new Note(this);
+    this.promises = false;
+  }
+  usePromises() {
+    this.promises = true;
+    return this;
+  }
+  promiseProxy(f, req) {
+    if (this.promises) {
+      const callbackHandler = this.callback;
+      return new Promise((resolve, reject) => {
+        const resolver = (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        };
+        req.end(r => callbackHandler(resolver, r));
+      });
+    } else {
+      req.end(r => this.callback(f, r));
+    }
   }
   ping(f) {
     unirest.get('https://api.intercom.io/admins')
@@ -44,55 +66,60 @@ export class Client {
     .end(r => f(r.status));
   }
   put(endpoint, data, f) {
-    unirest.put(`https://api.intercom.io${endpoint}`)
-    .auth(this.appId, this.appApiKey)
-    .type('json')
-    .send(data)
-    .header('Accept', 'application/json')
-    .header('User-Agent', 'intercom-node-client/1.0.0')
-    .end(r => this.callback(f, r));
+    return this.promiseProxy(f,
+      unirest.put(`https://api.intercom.io${endpoint}`)
+      .auth(this.appId, this.appApiKey)
+      .type('json')
+      .send(data)
+      .header('Accept', 'application/json')
+      .header('User-Agent', 'intercom-node-client/1.0.0')
+    );
   }
   post(endpoint, data, f) {
-    unirest.post(`https://api.intercom.io${endpoint}`)
-    .auth(this.appId, this.appApiKey)
-    .type('json')
-    .send(data)
-    .header('Accept', 'application/json')
-    .header('User-Agent', 'intercom-node-client/1.0.0')
-    .end(r => this.callback(f, r));
+    return this.promiseProxy(f,
+      unirest.post(`https://api.intercom.io${endpoint}`)
+      .auth(this.appId, this.appApiKey)
+      .type('json')
+      .send(data)
+      .header('Accept', 'application/json')
+      .header('User-Agent', 'intercom-node-client/1.0.0')
+    );
   }
   get(endpoint, data, f) {
-    unirest.get(`https://api.intercom.io${endpoint}`)
-    .auth(this.appId, this.appApiKey)
-    .type('json')
-    .query(data)
-    .header('Accept', 'application/json')
-    .header('User-Agent', 'intercom-node-client/1.0.0')
-    .end(r => this.callback(f, r));
+    return this.promiseProxy(f,
+      unirest.get(`https://api.intercom.io${endpoint}`)
+      .auth(this.appId, this.appApiKey)
+      .type('json')
+      .query(data)
+      .header('Accept', 'application/json')
+      .header('User-Agent', 'intercom-node-client/1.0.0')
+    );
   }
   nextPage(paginationObject, f) {
-    unirest.get(paginationObject.next)
-    .auth(this.appId, this.appApiKey)
-    .type('json')
-    .header('Accept', 'application/json')
-    .header('User-Agent', 'intercom-node-client/1.0.0')
-    .end(r => this.callback(f, r));
+    return this.promiseProxy(f,
+      unirest.get(paginationObject.next)
+      .auth(this.appId, this.appApiKey)
+      .type('json')
+      .header('Accept', 'application/json')
+      .header('User-Agent', 'intercom-node-client/1.0.0')
+    );
   }
   delete(endpoint, data, f) {
-    unirest.delete(`https://api.intercom.io${endpoint}`)
-    .auth(this.appId, this.appApiKey)
-    .type('json')
-    .query(data)
-    .header('Accept', 'application/json')
-    .header('User-Agent', 'intercom-node-client/1.0.0')
-    .end(r => this.callback(f, r));
+    return this.promiseProxy(f,
+      unirest.delete(`https://api.intercom.io${endpoint}`)
+      .auth(this.appId, this.appApiKey)
+      .type('json')
+      .query(data)
+      .header('Accept', 'application/json')
+      .header('User-Agent', 'intercom-node-client/1.0.0')
+    );
   }
   callback(f, data) {
     if (!f) {
       return;
     }
     if (f.length >= 2) {
-      let hasErrors = data.body && data.body.type === 'error.list';
+      let hasErrors = data.error || (data.body && data.body.type === 'error.list');
       if (hasErrors) {
         f(data, null);
       } else {

--- a/lib/company.js
+++ b/lib/company.js
@@ -3,18 +3,18 @@ export class Company {
     this.client = client;
   }
   create(data, f) {
-    this.client.post('/companies', data, f);
+    return this.client.post('/companies', data, f);
   }
   list(f) {
-    this.client.get('/companies', {}, f);
+    return this.client.get('/companies', {}, f);
   }
   listBy(params, f) {
-    this.client.get('/companies', params, f);
+    return this.client.get('/companies', params, f);
   }
   find(params, f) {
-    this.client.get(`/companies/${params.id}`, {}, f);
+    return this.client.get(`/companies/${params.id}`, {}, f);
   }
   listUsers(params, f) {
-    this.client.get(`/companies/${params.id}/users`, {}, f);
+    return this.client.get(`/companies/${params.id}/users`, {}, f);
   }
 }

--- a/lib/contact.js
+++ b/lib/contact.js
@@ -10,24 +10,24 @@ export class Contact {
       params = parameters_or_function;
       callback = arguments[1];
     }
-    this.client.post('/contacts', params, callback);
+    return this.client.post('/contacts', params, callback);
   }
   update(params, f) {
-    this.client.post('/contacts', params, f);
+    return this.client.post('/contacts', params, f);
   }
   list(f) {
-    this.client.get('/contacts', {}, f);
+    return this.client.get('/contacts', {}, f);
   }
   listBy(params, f) {
-    this.client.get('/contacts', params, f);
+    return this.client.get('/contacts', params, f);
   }
   find(params, f) {
-    this.client.get(`/contacts/${params.id}`, {}, f);
+    return this.client.get(`/contacts/${params.id}`, {}, f);
   }
   delete(params, f) {
-    this.client.delete(`/contacts/${params.id}`, {}, f);
+    return this.client.delete(`/contacts/${params.id}`, {}, f);
   }
   convert(params, f) {
-    this.client.post('/contacts/convert', params, f);
+    return this.client.post('/contacts/convert', params, f);
   }
 }

--- a/lib/conversation.js
+++ b/lib/conversation.js
@@ -3,15 +3,15 @@ export class Conversation {
     this.client = client;
   }
   list(data, f) {
-    this.client.get('/conversations', data, f);
+    return this.client.get('/conversations', data, f);
   }
   find(params, f) {
-    this.client.get(`/conversations/${params.id}`, params, f);
+    return this.client.get(`/conversations/${params.id}`, params, f);
   }
   reply(params, f) {
-    this.client.post(`/conversations/${params.id}/reply`, params, f);
+    return this.client.post(`/conversations/${params.id}/reply`, params, f);
   }
   markAsRead(params, f) {
-    this.client.put(`/conversations/${params.id}`, { read: true }, f);
+    return this.client.put(`/conversations/${params.id}`, { read: true }, f);
   }
 }

--- a/lib/counts.js
+++ b/lib/counts.js
@@ -3,27 +3,27 @@ export class Counts {
     this.client = client;
   }
   appCounts(f) {
-    this.client.get('/counts', {}, f);
+    return this.client.get('/counts', {}, f);
   }
   conversationCounts(f) {
-    this.client.get('/counts', { type: 'conversation' }, f);
+    return this.client.get('/counts', { type: 'conversation' }, f);
   }
   conversationAdminCounts(f) {
-    this.client.get('/counts', { type: 'conversation', count: 'admin' }, f);
+    return this.client.get('/counts', { type: 'conversation', count: 'admin' }, f);
   }
   userTagCounts(f) {
-    this.client.get('/counts', { type: 'user', count: 'tag' }, f);
+    return this.client.get('/counts', { type: 'user', count: 'tag' }, f);
   }
   userSegmentCounts(f) {
-    this.client.get('/counts', { type: 'user', count: 'segment' }, f);
+    return this.client.get('/counts', { type: 'user', count: 'segment' }, f);
   }
   companyTagCounts(f) {
-    this.client.get('/counts', { type: 'company', count: 'tag' }, f);
+    return this.client.get('/counts', { type: 'company', count: 'tag' }, f);
   }
   companySegmentCounts(f) {
-    this.client.get('/counts', { type: 'company', count: 'segment' }, f);
+    return this.client.get('/counts', { type: 'company', count: 'segment' }, f);
   }
   companyUserCounts(f) {
-    this.client.get('/counts', { type: 'company', count: 'user' }, f);
+    return this.client.get('/counts', { type: 'company', count: 'user' }, f);
   }
 }

--- a/lib/event.js
+++ b/lib/event.js
@@ -5,9 +5,9 @@ export class Event {
     this.client = client;
   }
   create(data, f) {
-    this.client.post('/events', data, f);
+    return this.client.post('/events', data, f);
   }
   bulk(params, f) {
-    new Bulk(this.client, 'event').bulk(params, f);
+    return new Bulk(this.client, 'event').bulk(params, f);
   }
 }

--- a/lib/message.js
+++ b/lib/message.js
@@ -3,6 +3,6 @@ export class Message {
     this.client = client;
   }
   create(data, f) {
-    this.client.post('/messages', data, f);
+    return this.client.post('/messages', data, f);
   }
 }

--- a/lib/note.js
+++ b/lib/note.js
@@ -3,12 +3,12 @@ export class Note {
     this.client = client;
   }
   create(params, f) {
-    this.client.post('/notes', params, f);
+    return this.client.post('/notes', params, f);
   }
   list(params, f) {
-    this.client.get('/notes', params, f);
+    return this.client.get('/notes', params, f);
   }
   find(params, f) {
-    this.client.get(`/notes/${params.id}`, {}, f);
+    return this.client.get(`/notes/${params.id}`, {}, f);
   }
 }

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -3,9 +3,9 @@ export class Segment {
     this.client = client;
   }
   list(f) {
-    this.client.get('/segments', {}, f);
+    return this.client.get('/segments', {}, f);
   }
   find(params, f) {
-    this.client.get(`/segments/${params.id}`, {}, f);
+    return this.client.get(`/segments/${params.id}`, {}, f);
   }
 }

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -3,20 +3,20 @@ export class Tag {
     this.client = client;
   }
   create(data, f) {
-    this.client.post('/tags', data, f);
+    return this.client.post('/tags', data, f);
   }
   tag(data, f) {
-    this.client.post('/tags', data, f);
+    return this.client.post('/tags', data, f);
   }
   untag(data, f) {
     (data.users || []).forEach(user => user.untag = true);
     (data.companies || []).forEach(company => company.untag = true);
-    this.client.post('/tags', data, f);
+    return this.client.post('/tags', data, f);
   }
   delete(params, f) {
-    this.client.delete(`/tags/${params.id}`, {}, f);
+    return this.client.delete(`/tags/${params.id}`, {}, f);
   }
   list(f) {
-    this.client.get('/tags', {}, f);
+    return this.client.get('/tags', {}, f);
   }
 }

--- a/lib/user.js
+++ b/lib/user.js
@@ -5,21 +5,21 @@ export class User {
     this.client = client;
   }
   create(data, f) {
-    this.client.post('/users', data, f);
+    return this.client.post('/users', data, f);
   }
   list(f) {
-    this.client.get('/users', {}, f);
+    return this.client.get('/users', {}, f);
   }
   listBy(params, f) {
-    this.client.get('/users', params, f);
+    return this.client.get('/users', params, f);
   }
   find(params, f) {
-    this.client.get(`/users/${params.id}`, {}, f);
+    return this.client.get(`/users/${params.id}`, {}, f);
   }
   delete(params, f) {
-    this.client.delete(`/users/${params.id}`, {}, f);
+    return this.client.delete(`/users/${params.id}`, {}, f);
   }
   bulk(params, f) {
-    new Bulk(this.client, 'user').bulk(params, f);
+    return (new Bulk(this.client, 'user').bulk(params, f));
   }
 }

--- a/test/admin.js
+++ b/test/admin.js
@@ -5,8 +5,8 @@ var nock = require('nock');
 describe('admins', function () {
   it('should be listed', function (done) {
     nock('https://api.intercom.io').get('/admins').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.admins.list(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.admins.list().then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/bulk.js
+++ b/test/bulk.js
@@ -22,11 +22,11 @@ describe('bulk', function () {
         }
       ]
     }).reply(200, {});
-    let client = new Client('foo', 'bar');
+    let client = new Client('foo', 'bar').usePromises();
     client.users.bulk([
       { create: { email: 'wash@serenity.io' }},
       { create: { email: 'mal@serenity.io'}}
-    ], function (r) {
+    ]).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
@@ -50,11 +50,11 @@ describe('bulk', function () {
         }
       ]
     }).reply(200, {});
-    let client = new Client('foo', 'bar');
+    let client = new Client('foo', 'bar').usePromises();
     client.events.bulk([
       { create: { foo: 'bar' }},
       { create: { bar: 'baz'}}
-    ], function (r) {
+    ]).then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/client.js
+++ b/test/client.js
@@ -1,7 +1,26 @@
 import assert from 'assert';
 import {Client} from '../lib';
+import nock from 'nock';
 
 describe('clients', function () {
+  it('should resolve promises', function (done) {
+    nock('https://api.intercom.io').get('/users').reply(200, {});
+    let client = new Client('foo', 'bar').usePromises();
+    assert.equal(true, client.promises);
+    client.users.list().then(function (r) {
+      assert.equal(200, r.status);
+      done();
+    });
+  });
+  it('should reject promises', function (done) {
+    nock('https://api.intercom.io').get('/users').reply(200, {type: 'error.list'});
+    let client = new Client('foo', 'bar').usePromises();
+    assert.equal(true, client.promises);
+    client.users.list().catch(err => {
+      assert.equal('error.list', err.body.type);
+      done();
+    });
+  });
   it('should callback with errors', function (done) {
     let callback = function (err, d) {
       assert.equal('error.list', err.body.type);

--- a/test/company.js
+++ b/test/company.js
@@ -5,40 +5,40 @@ var nock = require('nock');
 describe('companies', function () {
   it('should be created', function (done) {
     nock('https://api.intercom.io').post('/companies', { name: 'baz' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.companies.create({ name: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.companies.create({ name: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should list', function (done) {
     nock('https://api.intercom.io').get('/companies').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.companies.list(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.companies.list().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should list by params', function (done) {
     nock('https://api.intercom.io').get('/companies').query({ tag_id: '1234' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.companies.listBy({ tag_id: '1234' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.companies.listBy({ tag_id: '1234' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('find companies by id', function (done) {
     nock('https://api.intercom.io').get('/companies/baz').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.companies.find({ id: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.companies.find({ id: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('list company users by id', function (done) {
     nock('https://api.intercom.io').get('/companies/baz/users').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.companies.listUsers({ id: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.companies.listUsers({ id: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/contact.js
+++ b/test/contact.js
@@ -5,56 +5,56 @@ var nock = require('nock');
 describe('contacts', function () {
   it('should be created', function (done) {
     nock('https://api.intercom.io').post('/contacts').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.contacts.create(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.contacts.create().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should be created with parameters', function (done) {
     nock('https://api.intercom.io').post('/contacts', { foo: 'bar' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.contacts.create({ foo: 'bar' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.contacts.create({ foo: 'bar' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should be updated', function (done) {
     nock('https://api.intercom.io').post('/contacts', { id: 'baz', email: 'foo@intercom.io' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.contacts.update({ id: 'baz', email: 'foo@intercom.io' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.contacts.update({ id: 'baz', email: 'foo@intercom.io' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should list', function (done) {
     nock('https://api.intercom.io').get('/contacts').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.contacts.list(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.contacts.list().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should list by params', function (done) {
     nock('https://api.intercom.io').get('/contacts').query({ email: 'jayne@serenity.io' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.contacts.listBy({ email: 'jayne@serenity.io' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.contacts.listBy({ email: 'jayne@serenity.io' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should find by id', function (done) {
     nock('https://api.intercom.io').get('/contacts/baz').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.contacts.find({ id: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.contacts.find({ id: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('delete by id', function (done) {
     nock('https://api.intercom.io').delete('/contacts/baz').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.contacts.delete({ id: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.contacts.delete({ id: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
@@ -65,8 +65,8 @@ describe('contacts', function () {
       user: { email: 'bang' }
     };
     nock('https://api.intercom.io').post('/contacts/convert', conversionObject).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.contacts.convert(conversionObject, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.contacts.convert(conversionObject).then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/conversation.js
+++ b/test/conversation.js
@@ -5,32 +5,32 @@ var nock = require('nock');
 describe('conversations', function () {
   it('should be listed', function (done) {
     nock('https://api.intercom.io').get('/conversations').query({ foo: 'bar' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.conversations.list({ foo: 'bar' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.conversations.list({ foo: 'bar' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should find', function (done) {
     nock('https://api.intercom.io').get('/conversations/bar').query({ id: 'bar' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.conversations.find({ id: 'bar' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.conversations.find({ id: 'bar' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should reply', function (done) {
     nock('https://api.intercom.io').post('/conversations/bar/reply', { id: 'bar', baz: 'bang' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.conversations.reply({ id: 'bar', baz: 'bang' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.conversations.reply({ id: 'bar', baz: 'bang' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should mark as read', function (done) {
     nock('https://api.intercom.io').put('/conversations/bar', { read: true }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.conversations.markAsRead({ id: 'bar' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.conversations.markAsRead({ id: 'bar' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/counts.js
+++ b/test/counts.js
@@ -5,64 +5,64 @@ var nock = require('nock');
 describe('counts', function () {
   it('app counts', function (done) {
     nock('https://api.intercom.io').get('/counts').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.counts.appCounts(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.counts.appCounts().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('conversation app counts', function (done) {
     nock('https://api.intercom.io').get('/counts').query({ type: 'conversation' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.counts.conversationCounts(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.counts.conversationCounts().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('conversation admin counts', function (done) {
     nock('https://api.intercom.io').get('/counts').query({ type: 'conversation', count: 'admin' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.counts.conversationAdminCounts(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.counts.conversationAdminCounts().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('user tag counts', function (done) {
     nock('https://api.intercom.io').get('/counts').query({ type: 'user', count: 'tag' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.counts.userTagCounts(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.counts.userTagCounts().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('user segment counts', function (done) {
     nock('https://api.intercom.io').get('/counts').query({ type: 'user', count: 'segment' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.counts.userSegmentCounts(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.counts.userSegmentCounts().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('company tag counts', function (done) {
     nock('https://api.intercom.io').get('/counts').query({ type: 'company', count: 'tag' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.counts.companyTagCounts(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.counts.companyTagCounts().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('company segment counts', function (done) {
     nock('https://api.intercom.io').get('/counts').query({ type: 'company', count: 'segment' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.counts.companySegmentCounts(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.counts.companySegmentCounts().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('company user counts', function (done) {
     nock('https://api.intercom.io').get('/counts').query({ type: 'company', count: 'user' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.counts.companyUserCounts(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.counts.companyUserCounts().then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/event.js
+++ b/test/event.js
@@ -5,12 +5,12 @@ var nock = require('nock');
 describe('events', function () {
   it('should be created', function (done) {
     nock('https://api.intercom.io').post('/events', { event_name: 'Foo', created_at: 1234, user_id: 'bar' }).reply(200, {});
-    let client = new Client('foo', 'bar');
+    let client = new Client('foo', 'bar').usePromises();
     client.events.create({
       event_name: 'Foo',
       created_at: 1234,
       user_id: 'bar'
-    }, function (r) {
+    }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/index.js
+++ b/test/index.js
@@ -18,9 +18,9 @@ describe('clients', function () {
   });
   it('paginate', function (done) {
     nock('https://api.intercom.io').get('/foo/bar/baz').query({ blue: 'red' }).reply(200, { foo: 'bar' });
-    let client = new Client('foo', 'bar');
+    let client = new Client('foo', 'bar').usePromises();
     let paginationObject = { next: 'https://api.intercom.io/foo/bar/baz?blue=red' };
-    client.nextPage(paginationObject, function (r) {
+    client.nextPage(paginationObject).then(function (r) {
       assert.deepEqual({foo: 'bar'}, r.body);
       done();
     });

--- a/test/message.js
+++ b/test/message.js
@@ -5,8 +5,8 @@ var nock = require('nock');
 describe('messages', function () {
   it('should be created', function (done) {
     nock('https://api.intercom.io').post('/messages', { message_type: 'foo' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.messages.create({ message_type: 'foo' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.messages.create({ message_type: 'foo' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/note.js
+++ b/test/note.js
@@ -5,24 +5,24 @@ var nock = require('nock');
 describe('notes', function () {
   it('should be created', function (done) {
     nock('https://api.intercom.io').post('/notes', { foo: 'bar' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.notes.create({ foo: 'bar' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.notes.create({ foo: 'bar' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should list', function (done) {
     nock('https://api.intercom.io').get('/notes').query({ foo: 'bar' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.notes.list({ foo: 'bar' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.notes.list({ foo: 'bar' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should find notes by id', function (done) {
     nock('https://api.intercom.io').get('/notes/bar').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.notes.find({ id: 'bar' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.notes.find({ id: 'bar' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/segment.js
+++ b/test/segment.js
@@ -5,16 +5,16 @@ var nock = require('nock');
 describe('segments', function () {
   it('should be listed', function (done) {
     nock('https://api.intercom.io').get('/segments').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.segments.list(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.segments.list().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('find by id', function (done) {
     nock('https://api.intercom.io').get('/segments/baz').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.segments.find({ id: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.segments.find({ id: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/tag.js
+++ b/test/tag.js
@@ -5,48 +5,48 @@ var nock = require('nock');
 describe('tags', function () {
   it('should be created/updated', function (done) {
     nock('https://api.intercom.io').post('/tags').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.tags.create({ name: 'haven' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.tags.create({ name: 'haven' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should tag users and companies', function (done) {
     nock('https://api.intercom.io').post('/tags', { name: 'haven', users: [{ id: '5534534' }] }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.tags.tag({ name: 'haven', users: [{ id: '5534534' }] }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.tags.tag({ name: 'haven', users: [{ id: '5534534' }] }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should untag users', function (done) {
     nock('https://api.intercom.io').post('/tags', { name: 'haven', users: [{ id: '5534534', untag: true }] }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.tags.untag({ name: 'haven', users: [{ id: '5534534' }] }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.tags.untag({ name: 'haven', users: [{ id: '5534534' }] }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should untag companies', function (done) {
     nock('https://api.intercom.io').post('/tags', { name: 'haven', companies: [{ id: '5534534', untag: true }] }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.tags.untag({ name: 'haven', companies: [{ id: '5534534' }] }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.tags.untag({ name: 'haven', companies: [{ id: '5534534' }] }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should delete tags', function (done) {
     nock('https://api.intercom.io').delete('/tags/baz').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.tags.delete({ id: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.tags.delete({ id: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should list', function (done) {
     nock('https://api.intercom.io').get('/tags').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.tags.list(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.tags.list().then(function (r) {
       assert.equal(200, r.status);
       done();
     });

--- a/test/user.js
+++ b/test/user.js
@@ -5,40 +5,40 @@ var nock = require('nock');
 describe('users', function () {
   it('should be created', function (done) {
     nock('https://api.intercom.io').post('/users', { email: 'foo@bar.com' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.users.create({ email: 'foo@bar.com' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.users.create({ email: 'foo@bar.com' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should list', function (done) {
     nock('https://api.intercom.io').get('/users').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.users.list(function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.users.list().then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should list by params', function (done) {
     nock('https://api.intercom.io').get('/users').query({ tag_id: '1234' }).reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.users.listBy({ tag_id: '1234' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.users.listBy({ tag_id: '1234' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should find users by id', function (done) {
     nock('https://api.intercom.io').get('/users/baz').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.users.find({ id: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.users.find({ id: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });
   });
   it('should delete users by id', function (done) {
     nock('https://api.intercom.io').delete('/users/baz').reply(200, {});
-    let client = new Client('foo', 'bar');
-    client.users.delete({ id: 'baz' }, function (r) {
+    let client = new Client('foo', 'bar').usePromises();
+    client.users.delete({ id: 'baz' }).then(function (r) {
       assert.equal(200, r.status);
       done();
     });


### PR DESCRIPTION
This drops in optional support for promises:

```node
let client = new Client('foo', 'bar').usePromises()
client.users.create({ email: 'foo@bar.com' }).then(function (r) {
   // ...
});
```

Due to the lack of implicit return, I've had to modify all of the models. As I result I've also rewritten all of the tests into promise format.

This shouldn't be a breaking change, but will probably be a major release.

The actual new promise code: https://github.com/intercom/intercom-node/pull/47/files#diff-50cfa59973c04321b5da0c6da0fdf4feR43

I have not looked into ES7 async stuff. Once we have an API in place we can iterate on that if necessary.