### PR TITLE
Refactored client to use Bluebird for promises

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,5 @@
 import unirest from 'unirest';
+import Bluebird from 'bluebird';
 import User from './user';
 import Event from './event';
 import Company from './company';
@@ -43,7 +44,7 @@ export default class Client {
   promiseProxy(f, req) {
     if (this.promises) {
       const callbackHandler = this.callback;
-      return new Promise((resolve, reject) => {
+      return new Bluebird((resolve, reject) => {
         const resolver = (err, data) => {
           if (err) {
             reject(err);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "babel-eslint": "^4.1.3",
+    "bluebird": "^3.0.5",
     "unirest": "^0.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Here is a the change just dropping in `Bluebird` for promises - you'll see that it's already added helpful output
<img width="840" alt="screenshot 2015-11-03 07 36 33" src="https://cloud.githubusercontent.com/assets/2721959/10912342/e6db6f6c-81fd-11e5-8e0e-641b9706dc47.png">

I kept the client the same as you had before but it is following the promise constructor anti-pattern. A different approach would be to just promisifying the `unirest` lib if the client is using promises - this would lead to cleaner code and you won't have to reinvent the wheel with `if (err) reject.. else resolve`. Also it prevents edge cases like the `unirest` lib throwing an error synchronously or multiple success values.

[Check this out](http://bluebirdjs.com/docs/anti-patterns.html#explicit-construction-anti-pattern) to see more details on the anti-pattern