### PR TITLE
Add support for adding more task to jobs on Intercom

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -3,7 +3,7 @@ export default class Bulk {
     this.client = client;
     this.dataType = dataType;
   }
-  bulk(bulkOperations, f) {
+  bulkJob(bulkOperations, jobId, f) {
     const dataType = this.dataType;
     const bulkParams = { items: [] };
     const url = `/bulk/${dataType}s`;
@@ -21,6 +21,14 @@ export default class Bulk {
         });
       }
     });
+    if (jobId) {
+      bulkParams.job = {
+        id: jobId
+      };
+    }
     return this.client.post(url, bulkParams, f);
+  }
+  bulk(bulkOperations, f) {
+    return this.bulkJob(bulkOperations, null, f);
   }
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -12,6 +12,7 @@ import Segment from './segment';
 import Message from './message';
 import Conversation from './conversation';
 import Note from './note';
+import Job from './job';
 
 export default class Client {
   constructor(...args) {
@@ -43,6 +44,7 @@ export default class Client {
     this.messages = new Message(this);
     this.conversations = new Conversation(this);
     this.notes = new Note(this);
+    this.jobs = new Job(this);
     this.promises = false;
     this.baseUrl = 'https://api.intercom.io';
   }

--- a/lib/event.js
+++ b/lib/event.js
@@ -11,6 +11,9 @@ export default class Event {
     return this.client.get('/events', params, f);
   }
   bulk(params, f) {
-    return new Bulk(this.client, 'event').bulk(params, f);
+    return (new Bulk(this.client, 'event').bulk(params, f));
+  }
+  bulkJob(params, jobId, f) {
+    return (new Bulk(this.client, 'event').bulkJob(params, jobId, f));
   }
 }

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,0 +1,11 @@
+export default class Job {
+  constructor(client) {
+    this.client = client;
+  }
+  find(params, f) {
+    return this.client.get(`/jobs/${params.id}`, {}, f);
+  }
+  error(params, f) {
+    return this.client.get(`/jobs/${params.id}/error`, {}, f);
+  }
+}

--- a/lib/user.js
+++ b/lib/user.js
@@ -39,4 +39,7 @@ export default class User {
   bulk(params, f) {
     return (new Bulk(this.client, 'user').bulk(params, f));
   }
+  bulkJob(params, jobId, f) {
+    return (new Bulk(this.client, 'user').bulkJob(params, jobId, f));
+  }
 }

--- a/test/bulk.js
+++ b/test/bulk.js
@@ -27,7 +27,39 @@ describe('bulk', () => {
       { create: { email: 'wash@serenity.io' }},
       { create: { email: 'mal@serenity.io'}}
     ]).then(r => {
+      let reqJSON = JSON.parse(r.request.body.toString());
       assert.equal(200, r.status);
+      assert.equal(undefined, reqJSON.job);
+      done();
+    });
+  });
+  it('should send bulk users with job id', done => {
+    nock('https://api.intercom.io').post('/bulk/users', {
+      items: [
+        {
+          method: 'post',
+          data_type: 'user',
+          data: {
+            email: 'wash@serenity.io'
+          }
+        },
+        {
+          method: 'post',
+          data_type: 'user',
+          data: {
+            email: 'mal@serenity.io'
+          }
+        }
+      ]
+    }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.bulkJob([
+      { create: { email: 'wash@serenity.io' }},
+      { create: { email: 'mal@serenity.io'}}
+    ], 'jobId').then(r => {
+      let reqJSON = JSON.parse(r.request.body.toString());
+      assert.equal(200, r.status);
+      assert.equal('jobId', reqJSON.job.id);
       done();
     });
   });
@@ -55,7 +87,39 @@ describe('bulk', () => {
       { create: { foo: 'bar' }},
       { create: { bar: 'baz'}}
     ]).then(r => {
+      let reqJSON = JSON.parse(r.request.body.toString());
       assert.equal(200, r.status);
+      assert.equal(undefined, reqJSON.job);
+      done();
+    });
+  });
+  it('should send bulk events with job id', done => {
+    nock('https://api.intercom.io').post('/bulk/events', {
+      items: [
+        {
+          method: 'post',
+          data_type: 'event',
+          data: {
+            foo: 'bar'
+          }
+        },
+        {
+          method: 'post',
+          data_type: 'event',
+          data: {
+            bar: 'baz'
+          }
+        }
+      ]
+    }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.events.bulkJob([
+      { create: { foo: 'bar' }},
+      { create: { bar: 'baz'}}
+    ], 'jobId').then(r => {
+      let reqJSON = JSON.parse(r.request.body.toString());
+      assert.equal(200, r.status);
+      assert.equal('jobId', reqJSON.job.id);
       done();
     });
   });

--- a/test/job.js
+++ b/test/job.js
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import {Client} from '../lib';
+import nock from 'nock';
+
+describe('jobs', () => {
+  it('should find jobs by id', done => {
+    const jobId = 'job_id';
+    nock('https://api.intercom.io').get(`/jobs/${jobId}`).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.jobs.find({id: jobId}).then(r => {
+      assert.equal(200, r.status);
+      done();
+    });
+  });
+  it('should find job\'s errors by id', done => {
+    const jobId = 'job_id';
+    nock('https://api.intercom.io').get(`/jobs/${jobId}/error`).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.jobs.error({id: jobId}).then(r => {
+      assert.equal(200, r.status);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Missing this particular feature making bulk jobs less than useful.

Changes:
- Add `bulkJob` so we can send request with a `jobId`
- Bulk now rely on bulkJob.
- Add `intercomClient.jobs.find` and `intercomClient.jobs.error` to get the job results.
- Tests
