### PR TITLE
default to returning a promise when callbacks are absent

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -43,7 +43,7 @@ export default class Client {
     return this;
   }
   promiseProxy(f, req) {
-    if (this.promises) {
+    if (this.promises || !f) {
       const callbackHandler = this.callback;
       return new Bluebird((resolve, reject) => {
         const resolver = (err, data) => {

--- a/test/client.js
+++ b/test/client.js
@@ -12,6 +12,14 @@ describe('clients', () => {
       done();
     });
   });
+  it('should use promises when callbacks are absent', done => {
+    nock('https://api.intercom.io').get('/users').reply(200, {});
+    const client = new Client('foo', 'bar');
+    client.users.list().then(r => {
+      assert.equal(200, r.status);
+      done();
+    });
+  });
   it('should reject promises', done => {
     nock('https://api.intercom.io').get('/users').reply(200, {type: 'error.list'});
     const client = new Client('foo', 'bar').usePromises();


### PR DESCRIPTION
We can deprecate the `usePromises` flag after this.

fixes https://github.com/intercom/intercom-node/issues/52