### PR TITLE
Update README to reflect updated promise behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,9 @@ client.users.list(function (err, d) {
 
 ## Promises
 
-This client library also supports using Promises instead of callbacks by calling `usePromises` on the client object:
+This client library also supports using Promises instead of callbacks:
 
 ```node
-let client = new Client('foo', 'bar').usePromises();
 client.users.create({ email: 'foo@bar.com' }).then(function (r) {
   // ...
 });


### PR DESCRIPTION
Original `usePromises` method was deprecated in #86