### PR TITLE
Make users.scroll return a promise and wait for inner promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ client.users.listBy({ tag_id: 'haven' }, callback);
 // Scroll through users list
 client.users.scroll.each({}, function(d) {
   console.log(d.body.users);
+  // if you return a promise from your callback, the client will only scroll
+  // after this promise has resolved
 });
 ```
 

--- a/lib/scroll.js
+++ b/lib/scroll.js
@@ -1,21 +1,42 @@
+import Bluebird from 'bluebird';
+
 export default class Scroll {
   constructor(client, dataType) {
     this.client = client;
     this.dataType = dataType;
   }
   each(params, f) {
-    this.scroll_params = undefined;
-    this.eachInternal(params, f);
-  }
-  eachInternal(params, f) {
     var self = this;
-    this.client.get(this.scrollUrl(), params).then(function (res) {
-      f(res);
-      if (res.body[`${self.dataType}s`].length > 0) {
-        self.scroll_param = res.body.scroll_param;
-        self.eachInternal(params, f);
-      }
+    this.scroll_params = undefined;
+
+    return new Bluebird(function (resolve, reject) {
+      self.eachInternal(params, f, { resolve, reject });
     });
+  }
+  eachInternal(params, f, promise) {
+    var self = this;
+    this.client.get(this.scrollUrl(), params)
+      .then(function (response) {
+        var result = f(response);
+        if (response.body[`${self.dataType}s`].length > 0) {
+          self.scroll_param = response.body.scroll_param;
+          if (result && ('then' in result) && typeof result.then === 'function') {
+            result.then(function () {
+              self.eachInternal(params, f, promise);
+            }, function (error) {
+              promise.reject(error);
+            });
+          } else {
+            self.eachInternal(params, f, promise);
+          }
+
+        } else {
+          promise.resolve();
+        }
+      })
+      .catch(function (error) {
+        promise.reject(error);
+      });
   }
   scrollUrl() {
     const dataType = this.dataType;

--- a/test/scroll.js
+++ b/test/scroll.js
@@ -54,21 +54,17 @@ describe('scroll', () => {
     const client = new Client('foo', 'bar');
     let nbCalls = 0;
 
-    const promise = client.users.scroll.each({}, function (res) {
+    client.users.scroll.each({}, function (res) {
       nbCalls++;
 
       return res.body.users.length === 0 ?
-        null :
+        done() :
         new Bluebird((resolve) => {
           setTimeout(() => {
             assert.equal(1, nbCalls, 'hasn\'t re-scrolled before resolve');
             resolve();
           }, 500);
         });
-    });
-
-    promise.then(() => {
-      done();
     });
   });
 });

--- a/test/scroll.js
+++ b/test/scroll.js
@@ -3,7 +3,7 @@ import assert from 'assert';
 import {Client} from '../lib';
 import nock from 'nock';
 
-describe.only('scroll', () => {
+describe('scroll', () => {
   before(function () {
     nock('https://api.intercom.io').get('/users/scroll').times(3).reply(200, {
       type: 'user.list',

--- a/test/scroll.js
+++ b/test/scroll.js
@@ -1,10 +1,11 @@
+import Bluebird from 'bluebird';
 import assert from 'assert';
 import {Client} from '../lib';
 import nock from 'nock';
 
-describe('scroll', () => {
-  it('should get users with scroll', done => {
-    nock('https://api.intercom.io').get('/users/scroll').reply(200, {
+describe.only('scroll', () => {
+  before(function () {
+    nock('https://api.intercom.io').get('/users/scroll').times(3).reply(200, {
       type: 'user.list',
       scroll_param: '123_soleil',
       users: [
@@ -15,17 +16,59 @@ describe('scroll', () => {
         }
       ]
     });
-    nock('https://api.intercom.io').get('/users/scroll?scroll_param=123_soleil').reply(200, {
+
+    nock('https://api.intercom.io').get('/users/scroll?scroll_param=123_soleil').times(3).reply(200, {
       type: 'user.list',
       scroll_param: '123_soleil',
       users: []
     });
+  });
+
+  it('should get users with scroll', done => {
     const client = new Client('foo', 'bar');
+
     client.users.scroll.each({}, function (res) {
       assert.equal(200, res.status);
       if (res.body.users.length === 0) {
         done();
       }
+    });
+  });
+
+  it('should return a promise that resolves at the end of the scroll', done => {
+    const client = new Client('foo', 'bar');
+    let nbCalls = 0;
+
+    const promise = client.users.scroll.each({}, function () {
+      nbCalls++;
+    });
+
+    promise.then(() => {
+      assert.equal(2, nbCalls);
+
+      done();
+    });
+  });
+
+  it('should wait for promises returned by the callback before scrolling', done => {
+    const client = new Client('foo', 'bar');
+    let nbCalls = 0;
+
+    const promise = client.users.scroll.each({}, function (res) {
+      nbCalls++;
+
+      return res.body.users.length === 0 ?
+        null :
+        new Bluebird((resolve) => {
+          setTimeout(() => {
+            assert.equal(1, nbCalls, 'hasn\'t re-scrolled before resolve');
+            resolve();
+          }, 500);
+        });
+    });
+
+    promise.then(() => {
+      done();
     });
   });
 });


### PR DESCRIPTION
I've started using users.scroll but I had a few issues with this method.

First, unlike other methods of the API, this one didn't return a promise, which is inconsistent and made my life harder :-)

Secondly, this method gives me no control on when it will scroll. Basically, once started, it will scroll until the end of the list of users. In my use-case, I wanted to store in a DB a few info about the users I retrieved:
```js
client.users.scroll.each({}, function (res) {
  res.body.users.forEach((user) => {
    remoteDb.store(user.id, user.email);
  });
});
```
Doing this means that I will have a potentially HUGE number of concurrent queries to my database, and large memory consumption as well.

This patch makes it possible to return a Promise from the callback, and users.scroll will wait for this promise to resolve before scrolling:
```js
client.users.scroll.each({}, function (res) {
  return Promise.all(res.body.users.map((user) => {
    return remoteDb.store(user.id, user.email);
  }));
});
```

Thank you in advance!