### PR TITLE
Add ability to change intercom base url, for testing purposes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -44,9 +44,14 @@ export default class Client {
     this.conversations = new Conversation(this);
     this.notes = new Note(this);
     this.promises = false;
+    this.baseUrl = 'https://api.intercom.io';
   }
   usePromises() {
     this.promises = true;
+    return this;
+  }
+  useBaseUrl(baseUrl) {
+    this.baseUrl = baseUrl;
     return this;
   }
   promiseProxy(f, req) {
@@ -67,7 +72,7 @@ export default class Client {
     }
   }
   ping(f) {
-    unirest.get('https://api.intercom.io/admins')
+    unirest.get(`${this.baseUrl}/admins`)
     .auth(this.usernamePart, this.passwordPart)
     .type('json')
     .header('Accept', 'application/json')
@@ -76,7 +81,7 @@ export default class Client {
   }
   put(endpoint, data, f) {
     return this.promiseProxy(f,
-      unirest.put(`https://api.intercom.io${endpoint}`)
+      unirest.put(`${this.baseUrl}${endpoint}`)
       .auth(this.usernamePart, this.passwordPart)
       .type('json')
       .send(data)
@@ -86,7 +91,7 @@ export default class Client {
   }
   post(endpoint, data, f) {
     return this.promiseProxy(f,
-      unirest.post(`https://api.intercom.io${endpoint}`)
+      unirest.post(`${this.baseUrl}${endpoint}`)
       .auth(this.usernamePart, this.passwordPart)
       .type('json')
       .send(data)
@@ -96,7 +101,7 @@ export default class Client {
   }
   get(endpoint, data, f) {
     return this.promiseProxy(f,
-      unirest.get(`https://api.intercom.io${endpoint}`)
+      unirest.get(`${this.baseUrl}${endpoint}`)
       .auth(this.usernamePart, this.passwordPart)
       .type('json')
       .query(data)
@@ -115,7 +120,7 @@ export default class Client {
   }
   delete(endpoint, data, f) {
     return this.promiseProxy(f,
-      unirest.delete(`https://api.intercom.io${endpoint}`)
+      unirest.delete(`${this.baseUrl}${endpoint}`)
       .auth(this.usernamePart, this.passwordPart)
       .type('json')
       .query(data)

--- a/test/base-url.js
+++ b/test/base-url.js
@@ -1,0 +1,17 @@
+import assert from 'assert';
+import {Client} from '../lib';
+import nock from 'nock';
+
+describe('base-url', () => {
+  it('should be able to change base url', done => {
+    nock('http://local.test-server.com').get('/admins').reply(200, {});
+    const client = new Client('foo', 'bar')
+      .usePromises()
+      .useBaseUrl('http://local.test-server.com');
+
+    client.admins.list().then(r => {
+      assert.equal(200, r.status);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Basically a simple change, to make the client more testable. (For example, work against a stub server).