### PR TITLE
Add support for viewing an admin

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -5,6 +5,9 @@ export default class Admin {
   list(f) {
     return this.client.get('/admins', {}, f);
   }
+  find(id, f) {
+    return this.client.get(`/admins/${id}`, {}, f);
+  }
   me(f) {
     return this.client.get('/me', {}, f);
   }


### PR DESCRIPTION
Right now you can't get an admin from the API. You can only list them, but that will not return a full admin object.

Because the admin object is the only to get the avatar of an admin this is very needed,

This creates support for the `/admins/:id`, https://developers.intercom.com/reference#view-an-admin