### PR TITLE
Fix: properly reset scroll_param on new scroll

### DIFF
--- a/lib/scroll.js
+++ b/lib/scroll.js
@@ -7,7 +7,7 @@ export default class Scroll {
   }
   each(params, f) {
     var self = this;
-    this.scroll_params = undefined;
+    this.scroll_param = undefined;
 
     return new Bluebird(function (resolve, reject) {
       self.eachInternal(params, f, { resolve, reject });


### PR DESCRIPTION
The `each` function of a scroll should set `scroll_param` (not `scroll_params`) to `undefined`.