### PR TITLE
Remove Unirest from the codebase as it's unmaintained

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,4 @@
-import unirest from 'unirest';
+import request from 'request';
 import Bluebird from 'bluebird';
 import User from './user';
 import Event from './event';
@@ -54,7 +54,7 @@ export default class Client {
     this.baseUrl = baseUrl;
     return this;
   }
-  promiseProxy(f, req) {
+  promiseProxy(f, args) {
     if (this.promises || !f) {
       const callbackHandler = this.callback;
       return new Bluebird((resolve, reject) => {
@@ -65,68 +65,78 @@ export default class Client {
             resolve(data);
           }
         };
-        req.end(r => callbackHandler(resolver, r));
+        this.request(args, (_, r) => {
+          callbackHandler(resolver, r);
+        });
       });
     } else {
-      req.end(r => this.callback(f, r));
+      this.request(args, (_, r) => this.callback(f, r));
     }
   }
   ping(f) {
-    unirest.get(`${this.baseUrl}/admins`)
-    .auth(this.usernamePart, this.passwordPart)
-    .type('json')
-    .header('Accept', 'application/json')
-    .header('User-Agent', 'intercom-node-client/2.0.0')
-    .end(r => f(r.status));
+    this.request({
+      uri: '/admins'
+    }, (_, response) => f(response.statusCode));
   }
   put(endpoint, data, f) {
     return this.promiseProxy(f,
-      unirest.put(`${this.baseUrl}${endpoint}`)
-      .auth(this.usernamePart, this.passwordPart)
-      .type('json')
-      .send(data)
-      .header('Accept', 'application/json')
-      .header('User-Agent', 'intercom-node-client/2.0.0')
+      {
+        method: 'put',
+        uri: endpoint,
+        body: data
+      }
     );
   }
   post(endpoint, data, f) {
     return this.promiseProxy(f,
-      unirest.post(`${this.baseUrl}${endpoint}`)
-      .auth(this.usernamePart, this.passwordPart)
-      .type('json')
-      .send(data)
-      .header('Accept', 'application/json')
-      .header('User-Agent', 'intercom-node-client/2.0.0')
+      {
+        method: 'post',
+        uri: endpoint,
+        body: data
+      }
     );
   }
   get(endpoint, data, f) {
     return this.promiseProxy(f,
-      unirest.get(`${this.baseUrl}${endpoint}`)
-      .auth(this.usernamePart, this.passwordPart)
-      .type('json')
-      .query(data)
-      .header('Accept', 'application/json')
-      .header('User-Agent', 'intercom-node-client/2.0.0')
+      {
+        method: 'get',
+        uri: endpoint,
+        qs: data
+      }
     );
   }
   nextPage(paginationObject, f) {
     return this.promiseProxy(f,
-      unirest.get(paginationObject.next)
-      .auth(this.usernamePart, this.passwordPart)
-      .type('json')
-      .header('Accept', 'application/json')
-      .header('User-Agent', 'intercom-node-client/2.0.0')
+      {
+        method: 'get',
+        uri: paginationObject.next,
+        baseUrl: null
+      }
     );
   }
   delete(endpoint, data, f) {
     return this.promiseProxy(f,
-      unirest.delete(`${this.baseUrl}${endpoint}`)
-      .auth(this.usernamePart, this.passwordPart)
-      .type('json')
-      .query(data)
-      .header('Accept', 'application/json')
-      .header('User-Agent', 'intercom-node-client/2.0.0')
+      {
+        method: 'delete',
+        uri: endpoint,
+        qs: data
+      }
     );
+  }
+  request(args, callback) {
+    const defaultArgs = {
+      baseUrl: this.baseUrl,
+      json: true,
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'intercom-node-client/2.0.0'
+      }
+    };
+
+    return request(
+      Object.assign({}, defaultArgs, args),
+      callback
+    ).auth(this.usernamePart, this.passwordPart);
   }
   callback(f, data) {
     if (!f) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "bluebird": "^3.3.4",
-    "unirest": "^0.5.1"
+    "request": "^2.83.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.4",

--- a/test/admin.js
+++ b/test/admin.js
@@ -7,7 +7,7 @@ describe('admins', () => {
     nock('https://api.intercom.io').get('/admins').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.admins.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('admins', () => {
     nock('https://api.intercom.io').get('/me').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.admins.me().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('admins', () => {
     nock('https://api.intercom.io').get('/admins/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.admins.find('baz').then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/base-url.js
+++ b/test/base-url.js
@@ -10,7 +10,7 @@ describe('base-url', () => {
       .useBaseUrl('http://local.test-server.com');
 
     client.admins.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/bulk.js
+++ b/test/bulk.js
@@ -27,7 +27,7 @@ describe('bulk', () => {
       { create: { email: 'wash@serenity.io' }},
       { create: { email: 'mal@serenity.io'}}
     ]).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -55,7 +55,7 @@ describe('bulk', () => {
       { create: { foo: 'bar' }},
       { create: { bar: 'baz'}}
     ]).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/client.js
+++ b/test/client.js
@@ -8,7 +8,7 @@ describe('clients', () => {
     const client = new Client('foo', 'bar').usePromises();
     assert.equal(true, client.promises);
     client.users.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -16,7 +16,7 @@ describe('clients', () => {
     nock('https://api.intercom.io').get('/users').reply(200, {});
     const client = new Client('foo', 'bar');
     client.users.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/company.js
+++ b/test/company.js
@@ -7,7 +7,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').post('/companies', { name: 'baz' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.create({ name: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').get('/companies').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').get('/companies').query({ tag_id: '1234' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.listBy({ tag_id: '1234' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -31,7 +31,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').get('/companies/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.find({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -39,7 +39,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').get('/companies').query({ company_id: 'baz' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.find({ company_id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -47,7 +47,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').get('/companies').query({ name: 'baz' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.find({ name: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -55,7 +55,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').get('/companies/baz/users').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.listUsers({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -63,7 +63,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').get('/companies').query({ company_id: 'baz', type: 'user' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.listUsers({ company_id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -71,7 +71,7 @@ describe('companies', () => {
     nock('https://api.intercom.io').get('/companies').query({ name: 'baz', type: 'user' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.companies.listUsers({ name: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/contact.js
+++ b/test/contact.js
@@ -12,7 +12,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').post('/contacts').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.create().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -20,7 +20,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').post('/contacts', { foo: 'bar' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.create({ foo: 'bar' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').post('/contacts', { id: 'baz', email: 'foo@intercom.io' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.update({ id: 'baz', email: 'foo@intercom.io' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -36,7 +36,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').get('/contacts').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -44,7 +44,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').get('/contacts').query({ email: 'jayne@serenity.io' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.listBy({ email: 'jayne@serenity.io' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -52,7 +52,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').get('/contacts/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.find({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -60,7 +60,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').get('/contacts?user_id=baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.find({ user_id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -68,7 +68,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').delete('/contacts/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.delete({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -80,7 +80,7 @@ describe('contacts', () => {
     nock('https://api.intercom.io').post('/contacts/convert', conversionObject).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.leads.convert(conversionObject).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/conversation.js
+++ b/test/conversation.js
@@ -7,7 +7,7 @@ describe('conversations', () => {
     nock('https://api.intercom.io').get('/conversations').query({ foo: 'bar' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.conversations.list({ foo: 'bar' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('conversations', () => {
     nock('https://api.intercom.io').get('/conversations/bar').query({ id: 'bar' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.conversations.find({ id: 'bar' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('conversations', () => {
     nock('https://api.intercom.io').post('/conversations/bar/reply', { id: 'bar', baz: 'bang' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.conversations.reply({ id: 'bar', baz: 'bang' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -31,7 +31,7 @@ describe('conversations', () => {
     nock('https://api.intercom.io').put('/conversations/bar', { read: true }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.conversations.markAsRead({ id: 'bar' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/counts.js
+++ b/test/counts.js
@@ -7,7 +7,7 @@ describe('counts', () => {
     nock('https://api.intercom.io').get('/counts').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.counts.appCounts().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('counts', () => {
     nock('https://api.intercom.io').get('/counts').query({ type: 'conversation' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.counts.conversationCounts().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('counts', () => {
     nock('https://api.intercom.io').get('/counts').query({ type: 'conversation', count: 'admin' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.counts.conversationAdminCounts().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -31,7 +31,7 @@ describe('counts', () => {
     nock('https://api.intercom.io').get('/counts').query({ type: 'user', count: 'tag' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.counts.userTagCounts().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -39,7 +39,7 @@ describe('counts', () => {
     nock('https://api.intercom.io').get('/counts').query({ type: 'user', count: 'segment' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.counts.userSegmentCounts().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -47,7 +47,7 @@ describe('counts', () => {
     nock('https://api.intercom.io').get('/counts').query({ type: 'company', count: 'tag' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.counts.companyTagCounts().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -55,7 +55,7 @@ describe('counts', () => {
     nock('https://api.intercom.io').get('/counts').query({ type: 'company', count: 'segment' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.counts.companySegmentCounts().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -63,7 +63,7 @@ describe('counts', () => {
     nock('https://api.intercom.io').get('/counts').query({ type: 'company', count: 'user' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.counts.companyUserCounts().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/event.js
+++ b/test/event.js
@@ -11,7 +11,7 @@ describe('events', () => {
       created_at: 1234,
       user_id: 'bar'
     }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -19,7 +19,7 @@ describe('events', () => {
     nock('https://api.intercom.io').get('/events').query({ type: 'user', user_id: '1234' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.events.listBy({ type: 'user', user_id: '1234' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/message.js
+++ b/test/message.js
@@ -7,7 +7,7 @@ describe('messages', () => {
     nock('https://api.intercom.io').post('/messages', { message_type: 'foo' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.messages.create({ message_type: 'foo' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/note.js
+++ b/test/note.js
@@ -7,7 +7,7 @@ describe('notes', () => {
     nock('https://api.intercom.io').post('/notes', { foo: 'bar' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.notes.create({ foo: 'bar' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('notes', () => {
     nock('https://api.intercom.io').get('/notes').query({ foo: 'bar' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.notes.list({ foo: 'bar' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('notes', () => {
     nock('https://api.intercom.io').get('/notes/bar').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.notes.find({ id: 'bar' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/scroll.js
+++ b/test/scroll.js
@@ -28,7 +28,7 @@ describe('scroll', () => {
     const client = new Client('foo', 'bar');
 
     client.users.scroll.each({}, function (res) {
-      assert.equal(200, res.status);
+      assert.equal(200, res.statusCode);
       if (res.body.users.length === 0) {
         done();
       }

--- a/test/segment.js
+++ b/test/segment.js
@@ -7,7 +7,7 @@ describe('segments', () => {
     nock('https://api.intercom.io').get('/segments').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.segments.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('segments', () => {
     nock('https://api.intercom.io').get('/segments/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.segments.find({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/tag.js
+++ b/test/tag.js
@@ -7,7 +7,7 @@ describe('tags', () => {
     nock('https://api.intercom.io').post('/tags').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.tags.create({ name: 'haven' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('tags', () => {
     nock('https://api.intercom.io').post('/tags', { name: 'haven', users: [{ id: '5534534' }] }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.tags.tag({ name: 'haven', users: [{ id: '5534534' }] }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('tags', () => {
     nock('https://api.intercom.io').post('/tags', { name: 'haven', users: [{ id: '5534534', untag: true }] }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.tags.untag({ name: 'haven', users: [{ id: '5534534' }] }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -31,7 +31,7 @@ describe('tags', () => {
     nock('https://api.intercom.io').post('/tags', { name: 'haven', companies: [{ id: '5534534', untag: true }] }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.tags.untag({ name: 'haven', companies: [{ id: '5534534' }] }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -39,7 +39,7 @@ describe('tags', () => {
     nock('https://api.intercom.io').delete('/tags/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.tags.delete({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -47,7 +47,7 @@ describe('tags', () => {
     nock('https://api.intercom.io').get('/tags').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.tags.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/user.js
+++ b/test/user.js
@@ -7,7 +7,7 @@ describe('users', () => {
     nock('https://api.intercom.io').post('/users', { email: 'foo@bar.com' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.create({ email: 'foo@bar.com' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('users', () => {
     nock('https://api.intercom.io').post('/users', { email: 'foo@bar.com' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.update({ email: 'foo@bar.com' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('users', () => {
     nock('https://api.intercom.io').get('/users').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.list().then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -31,7 +31,7 @@ describe('users', () => {
     nock('https://api.intercom.io').get('/users').query({ tag_id: '1234' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.listBy({ tag_id: '1234' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -39,7 +39,7 @@ describe('users', () => {
     nock('https://api.intercom.io').get('/users/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.find({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -47,7 +47,7 @@ describe('users', () => {
     nock('https://api.intercom.io').get('/users').query({ user_id: 'foo' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.find({ user_id: 'foo' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -55,7 +55,7 @@ describe('users', () => {
     nock('https://api.intercom.io').get('/users').query({ email: 'foo' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.find({ email: 'foo' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -63,7 +63,7 @@ describe('users', () => {
     nock('https://api.intercom.io').delete('/users/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.delete({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -71,7 +71,7 @@ describe('users', () => {
     nock('https://api.intercom.io').delete('/users').query({ user_id: 'foo' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.delete({ user_id: 'foo' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -79,7 +79,7 @@ describe('users', () => {
     nock('https://api.intercom.io').delete('/users').query({ email: 'foo' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.delete({ email: 'foo' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });

--- a/test/visitor.js
+++ b/test/visitor.js
@@ -7,7 +7,7 @@ describe('visitors', () => {
     nock('https://api.intercom.io').post('/visitors', { id: 'baz', email: 'foo@intercom.io' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.visitors.update({ id: 'baz', email: 'foo@intercom.io' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -15,7 +15,7 @@ describe('visitors', () => {
     nock('https://api.intercom.io').get('/visitors').query({ user_id: '1234-5678-9876' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.visitors.find({ user_id: '1234-5678-9876' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -23,7 +23,7 @@ describe('visitors', () => {
     nock('https://api.intercom.io').get('/visitors/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.visitors.find({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -31,7 +31,7 @@ describe('visitors', () => {
     nock('https://api.intercom.io').delete('/visitors/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.visitors.delete({ id: 'baz' }).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -44,7 +44,7 @@ describe('visitors', () => {
     nock('https://api.intercom.io').post('/visitors/convert', conversionObject).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.visitors.convert(conversionObject).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });
@@ -56,7 +56,7 @@ describe('visitors', () => {
     nock('https://api.intercom.io').post('/visitors/convert', conversionObject).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.visitors.convert(conversionObject).then(r => {
-      assert.equal(200, r.status);
+      assert.equal(200, r.statusCode);
       done();
     });
   });


### PR DESCRIPTION
The current HTTP client, [`unirest`](https://github.com/Mashape/unirest-nodejs) depends on a library that has a security advisory alert. [I submitted a PR to them](https://github.com/Kong/unirest-nodejs/pull/112), but it doesn't look like the library is maintained any more. 

This removes `unirest` and introduces [`request`](https://github.com/request/request) which is an actively maintained http client. I removed the duplication of headers / auth by introducing a `request()` method. This change will fix https://github.com/intercom/intercom-node/issues/163.

This does slightly change the response however — request does not include a `status` key in the response, only `statusCode` key. I left the response alone and updated the tests. It would be possible to merge in a status key if required, but I opted against this as there are possibly more changes that I didn't notice, and it feels a bit like going down the rabbit hole trying to compare both. 