### PR TITLE
handle !data crash IN CALLBACK, issue #169

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -139,7 +139,7 @@ export default class Client {
     ).auth(this.usernamePart, this.passwordPart);
   }
   callback(f, data) {
-    if (!f) {
+    if (!f || !data) {
       return;
     }
     if (f.length >= 2) {


### PR DESCRIPTION
In order to avoid crash of Node.js app because of !data in callback

```
0:TypeError: Cannot read property 'error' of undefined
1: at callback (/app/node_modules/intercom-client/dist/client.js:221:30)
2: at Request._callback (/app/node_modules/intercom-client/dist/client.js:137:13)
3: at self.callback (/app/node_modules/request/request.js:186:22)
4: at emitOne (events.js:116:13)
```