### PR TITLE
Fix for #169 (TypeError: Cannot read property 'error' of undefined)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
   - 4
   - 6
   - 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+  - 4
+  - 6
+  - 8
   - 'stable'

--- a/lib/client.js
+++ b/lib/client.js
@@ -60,17 +60,17 @@ export default class Client {
       return new Bluebird((resolve, reject) => {
         const resolver = (err, data) => {
           if (err) {
-            reject(new Error(JSON.stringify(err)));
+            reject(err);
           } else {
             resolve(data);
           }
         };
-        this.request(args, (_, r) => {
-          callbackHandler(resolver, r);
+        this.request(args, (err, r) => {
+          callbackHandler(resolver, err, r);
         });
       });
     } else {
-      this.request(args, (_, r) => this.callback(f, r));
+      this.request(args, (err, r) => this.callback(f, err, r));
     }
   }
   ping(f) {
@@ -138,19 +138,29 @@ export default class Client {
       callback
     ).auth(this.usernamePart, this.passwordPart);
   }
-  callback(f, data) {
+  callback(f, err, res) {
     if (!f) {
       return;
     }
     if (f.length >= 2) {
-      const hasErrors = data.error || (data.body && data.body.type === 'error.list');
-      if (hasErrors) {
-        f(data, null);
+      if (res && res.body && res.body.type === 'error.list') {
+        let message = null;
+        if (Array.isArray(res.body.errors) && res.body.errors[0] && 'message' in res.body.errors) {
+          // Try to use the first errors message
+          message = res.body.errors[0].message;
+        }
+        err = new Error(message || 'Response error');
+        err.statusCode = res.statusCode;
+        err.body = res.body;
+        err.headers = res.headers;
+      }
+      if (err) {
+        f(err, null);
       } else {
-        f(null, data);
+        f(null, res);
       }
     } else {
-      f(data);
+      f(res || null);
     }
   }
 }

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,248 @@
+import assert from 'assert';
+import {Client} from '../lib';
+import nock from 'nock';
+
+describe.only('errors', () => {
+  describe('with promises', () => {
+    it('should fail with ESOCKETTIMEDOUT error', () => {
+
+      const socketErr = new Error('Socket timeout');
+      socketErr.code = 'ESOCKETTIMEDOUT';
+
+      nock('https://api.intercom.io').replyContentLength().get('/admins').replyWithError(socketErr);
+      const client = new Client('foo', 'bar').usePromises();
+      return client.admins.list().then(r => {
+        assert.strictEqual(r, null, 'Valid response');
+      }).catch(err => {
+        assert.deepStrictEqual(err, socketErr);
+      });
+    });
+    it('should fail with unauthorized (401) error', () => {
+      nock('https://api.intercom.io').replyContentLength().get('/admins').reply(401,
+        {
+          type: 'error.list',
+          request_id: 'b2i3ri5909msvfqskol0',
+          errors: [
+            {
+              code: 'token_unauthorized',
+              message: 'Not authorized to access resource'
+            }
+          ]
+        },
+        {
+          'X-Intercom-Version': '3736ab533ad11d88d93cdef3fcef9a98a5724229',
+          'X-RateLimit-Limit': '83',
+          'X-RateLimit-Remaining': '27',
+          'X-RateLimit-Reset': '1522850540',
+          'X-Request-Id': 'b2i3ri5909msvfqskol0',
+          'X-Runtime': '0.037708'
+        }
+      );
+      const client = new Client('foo', 'bar').usePromises();
+      return client.admins.list().then(r => {
+        assert.strictEqual(r, null, 'Valid response');
+      }).catch(err => {
+        assert.strictEqual(err.statusCode, 401);
+        assert.strictEqual(err.body.request_id, 'b2i3ri5909msvfqskol0');
+        assert.deepStrictEqual(err.body.errors, [{ code: 'token_unauthorized', message: 'Not authorized to access resource' }]);
+        assert.strictEqual(err.headers['x-request-id'], 'b2i3ri5909msvfqskol0');
+      });
+    });
+    it('should fail with too many requests (429) error', () => {
+      nock('https://api.intercom.io').replyContentLength().get('/me').reply(429,
+        {
+          type: 'error.list',
+          request_id: 'b2i3mhcboc6pcbe33q80',
+          errors: [
+            {
+              code: 'rate_limit_exceeded',
+              message: 'Exceeded rate limit of 83 in 10_seconds'
+            }
+          ]
+        },
+        {
+          'X-Intercom-Version': '3736ab533ad11d88d93cdef3fcef9a98a5724229',
+          'X-RateLimit-Limit': '83',
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': '1522849880',
+          'X-Request-Id': 'b2i3mhcboc6pcbe33q80',
+          'X-Runtime': '0.037708'
+        }
+      );
+      const client = new Client('foo', 'bar').usePromises();
+      return client.admins.me().then(r => {
+        assert.strictEqual(r, null, 'Valid response');
+      }).catch(err => {
+        assert.strictEqual(err.statusCode, 429);
+        assert.strictEqual(err.body.request_id, 'b2i3mhcboc6pcbe33q80');
+        assert.deepStrictEqual(err.body.errors, [{ code: 'rate_limit_exceeded', message: 'Exceeded rate limit of 83 in 10_seconds' }]);
+        assert.strictEqual(err.headers['x-request-id'], 'b2i3mhcboc6pcbe33q80');
+        assert.strictEqual(err.headers['x-ratelimit-reset'], '1522849880');
+      });
+    });
+  });
+
+  describe('with callback', () => {
+    describe('with 1 arg', () => {
+      it('should fail with ESOCKETTIMEDOUT error', done => {
+
+        const socketErr = new Error('Socket timeout');
+        socketErr.code = 'ESOCKETTIMEDOUT';
+
+        nock('https://api.intercom.io').replyContentLength().get('/admins').replyWithError(socketErr);
+        const client = new Client('foo', 'bar');
+        client.admins.list(r => {
+          assert.strictEqual(r, null, 'Valid response');
+
+          done();
+        });
+      });
+      it('should fail with unauthorized (401) error', done => {
+        nock('https://api.intercom.io').replyContentLength().get('/admins').reply(401,
+          {
+            type: 'error.list',
+            request_id: 'b2i3ri5909msvfqskol0',
+            errors: [
+              {
+                code: 'token_unauthorized',
+                message: 'Not authorized to access resource'
+              }
+            ]
+          },
+          {
+            'X-Intercom-Version': '3736ab533ad11d88d93cdef3fcef9a98a5724229',
+            'X-RateLimit-Limit': '83',
+            'X-RateLimit-Remaining': '27',
+            'X-RateLimit-Reset': '1522850540',
+            'X-Request-Id': 'b2i3ri5909msvfqskol0',
+            'X-Runtime': '0.037708'
+          }
+        );
+        const client = new Client('foo', 'bar');
+        client.admins.list(r => {
+          assert.strictEqual(r.statusCode, 401);
+          assert.strictEqual(r.body.type, 'error.list');
+          assert.strictEqual(r.body.request_id, 'b2i3ri5909msvfqskol0');
+          assert.ok(Array.isArray(r.body.errors));
+
+          done();
+        });
+      });
+      it('should fail with too many requests (429) error', done => {
+        nock('https://api.intercom.io').replyContentLength().get('/me').reply(429,
+          {
+            type: 'error.list',
+            request_id: 'b2i3mhcboc6pcbe33q80',
+            errors: [
+              {
+                code: 'rate_limit_exceeded',
+                message: 'Exceeded rate limit of 83 in 10_seconds'
+              }
+            ]
+          },
+          {
+            'X-Intercom-Version': '3736ab533ad11d88d93cdef3fcef9a98a5724229',
+            'X-RateLimit-Limit': '83',
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': '1522849880',
+            'X-Request-Id': 'b2i3mhcboc6pcbe33q80',
+            'X-Runtime': '0.037708'
+          }
+        );
+        const client = new Client('foo', 'bar');
+        client.admins.me(r => {
+          assert.strictEqual(r.statusCode, 429);
+          assert.strictEqual(r.body.type, 'error.list');
+          assert.strictEqual(r.body.request_id, 'b2i3mhcboc6pcbe33q80');
+          assert.ok(Array.isArray(r.body.errors));
+
+          done();
+        });
+      });
+    });
+    describe('with 2 args', () => {
+      it('should fail with ESOCKETTIMEDOUT error', done => {
+
+        const socketErr = new Error('Socket timeout');
+        socketErr.code = 'ESOCKETTIMEDOUT';
+
+        nock('https://api.intercom.io').replyContentLength().get('/admins').replyWithError(socketErr);
+        const client = new Client('foo', 'bar');
+        client.admins.list((err, r) => {
+          assert.strictEqual(r, null, 'Valid response');
+
+          assert.deepStrictEqual(err, socketErr);
+
+          done();
+        });
+      });
+      it('should fail with unauthorized (401) error', done => {
+        nock('https://api.intercom.io').replyContentLength().get('/admins').reply(401,
+          {
+            type: 'error.list',
+            request_id: 'b2i3ri5909msvfqskol0',
+            errors: [
+              {
+                code: 'token_unauthorized',
+                message: 'Not authorized to access resource'
+              }
+            ]
+          },
+          {
+            'X-Intercom-Version': '3736ab533ad11d88d93cdef3fcef9a98a5724229',
+            'X-RateLimit-Limit': '83',
+            'X-RateLimit-Remaining': '27',
+            'X-RateLimit-Reset': '1522850540',
+            'X-Request-Id': 'b2i3ri5909msvfqskol0',
+            'X-Runtime': '0.037708'
+          }
+        );
+        const client = new Client('foo', 'bar');
+        client.admins.list((err, r) => {
+          assert.strictEqual(r, null, 'Valid response');
+
+          assert.strictEqual(err.statusCode, 401);
+          assert.strictEqual(err.body.request_id, 'b2i3ri5909msvfqskol0');
+          assert.deepStrictEqual(err.body.errors, [{ code: 'token_unauthorized', message: 'Not authorized to access resource' }]);
+          assert.strictEqual(err.headers['x-request-id'], 'b2i3ri5909msvfqskol0');
+
+          done();
+        });
+      });
+      it('should fail with too many requests (429) error', done => {
+        nock('https://api.intercom.io').replyContentLength().get('/me').reply(429,
+          {
+            type: 'error.list',
+            request_id: 'b2i3mhcboc6pcbe33q80',
+            errors: [
+              {
+                code: 'rate_limit_exceeded',
+                message: 'Exceeded rate limit of 83 in 10_seconds'
+              }
+            ]
+          },
+          {
+            'X-Intercom-Version': '3736ab533ad11d88d93cdef3fcef9a98a5724229',
+            'X-RateLimit-Limit': '83',
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': '1522849880',
+            'X-Request-Id': 'b2i3mhcboc6pcbe33q80',
+            'X-Runtime': '0.037708'
+          }
+        );
+        const client = new Client('foo', 'bar');
+        client.admins.me((err, r) => {
+          assert.strictEqual(r, null, 'Valid response');
+
+          assert.strictEqual(err.statusCode, 429);
+          assert.strictEqual(err.body.request_id, 'b2i3mhcboc6pcbe33q80');
+          assert.deepStrictEqual(err.body.errors, [{ code: 'rate_limit_exceeded', message: 'Exceeded rate limit of 83 in 10_seconds' }]);
+          assert.strictEqual(err.headers['x-request-id'], 'b2i3mhcboc6pcbe33q80');
+          assert.strictEqual(err.headers['x-ratelimit-reset'], '1522849880');
+
+          done();
+        });
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -966,6 +972,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 doctrine@^0.6.2:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.6.4.tgz#81428491a942ef18b0492056eda3800eee57d61d"
@@ -1607,6 +1617,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-gulplog@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
@@ -1966,6 +1980,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2101,6 +2119,10 @@ lodash.escape@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -2186,6 +2208,10 @@ lodash@^4.0.0, lodash@^4.17.4:
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
+
+lolex@^2.2.0, lolex@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2321,6 +2347,16 @@ mute-stream@0.0.4:
 natives@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+
+nise@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.3.2.tgz#fd6fd8dc040dfb3c0a45252feb6ff21832309b14"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 nock@7.5.0:
   version "7.5.0"
@@ -2508,6 +2544,12 @@ path-root@^0.1.1:
   resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
   dependencies:
     path-root-regex "^0.1.0"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -2738,6 +2780,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
@@ -2757,6 +2803,18 @@ sequencify@~0.0.7:
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+
+sinon@^4.1.3:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.5.0.tgz#427ae312a337d3c516804ce2754e8c0d5028cb04"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    diff "^3.1.0"
+    lodash.get "^4.4.2"
+    lolex "^2.2.0"
+    nise "^1.2.0"
+    supports-color "^5.1.0"
+    type-detect "^4.0.5"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -2880,12 +2938,22 @@ supports-color@^3.1.0:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
 temp@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
   dependencies:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -2966,6 +3034,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
When no response is received (i.e. request error) there's no `data` here:
https://github.com/intercom/intercom-node/blob/8918db291ac15144c4d18148356ef5ec93088df8/lib/client.js#L141

This is due to the errors being ignored from `request` here:

https://github.com/intercom/intercom-node/blob/8918db291ac15144c4d18148356ef5ec93088df8/lib/client.js#L68-L70

and here:


https://github.com/intercom/intercom-node/blob/8918db291ac15144c4d18148356ef5ec93088df8/lib/client.js#L73

This PR has:

* Failing tests for request errors (using `nock` and [`replyWithError`](https://github.com/bookcreator/intercom-node/blob/bb2433994698a770dbd080617d3e4b2e8a84c7c3/test/errors.js#L12)).
* More tests for response errors (unauthorised 401s and rate limit 429s).
* Fix for #169 (and fixes #189) - by passing the error ([here](https://github.com/bookcreator/intercom-node/blob/71e0ca6fdb6f0832a153443f99e53797b98d798f/lib/client.js#L68-L70) and [here](https://github.com/bookcreator/intercom-node/blob/71e0ca6fdb6f0832a153443f99e53797b98d798f/lib/client.js#L73)) to the [callback function](https://github.com/bookcreator/intercom-node/blob/71e0ca6fdb6f0832a153443f99e53797b98d798f/lib/client.js#L141).
* Improved error handling so the [body/status code (and headers)](https://github.com/bookcreator/intercom-node/blob/71e0ca6fdb6f0832a153443f99e53797b98d798f/lib/client.js#L147-L155) can be used in client code as opposed to an error being [constructed from stringified JSON 🤢](https://github.com/intercom/intercom-node/blob/8918db291ac15144c4d18148356ef5ec93088df8/lib/client.js#L63) (also tests for this) - closes #130 and closes #106.
* Updated Travis CI to test with [LTS versions 4, 6, 8](https://github.com/bookcreator/intercom-node/commit/2d5130df957390857f5005b3cbc01e2204e2ef1c#diff-354f30a63fb0907d4ad57269548329e3) (as well as the existing versions) - closes #170 and closes #181.



Note this supersedes / closes #182 (as that silently ignores errors :-/ ).