### PR TITLE
Correct key for returned leads using scroll api

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ client.leads.scroll.each({}, function(res) {
   // after this promise has resolved
   new Bluebird((resolve) => {
     setTimeout(() => {
-      console.log(res.body.users.length);
+      console.log(res.body.contacts.length);
       // Your custom logic
       resolve();
    }, 500)


### PR DESCRIPTION
Leads are returned under the key `contacts` when using the scroll api.