### PR TITLE
Bump version to 2.9.4 to sync with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intercom-client",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "Official Node bindings to the Intercom API",
   "homepage": "https://github.com/intercom/intercom-node",
   "bugs:": "https://github.com/intercom/intercom-node/issues",


### PR DESCRIPTION
According to npm https://www.npmjs.com/package/intercom-client 2.9.4 was published, but the source code was not pushed to GitHub