### PR TITLE
chore: demote sinon to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "htmlencode": "^0.0.4",
-    "request": "^2.83.0",
-    "sinon": "^4.1.3"
+    "request": "^2.83.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.4",
@@ -36,7 +35,8 @@
     "gulp-mocha": "^2.0.0",
     "gulp-nsp": "^2.4.2",
     "gulp-plumber": "^1.1.0",
-    "nock": "7.5.0"
+    "nock": "7.5.0",
+    "sinon": "^4.1.3"
   },
   "scripts": {
     "prepublish": "gulp prepublish",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-nsp": "^2.4.2",
     "gulp-plumber": "^1.1.0",
     "nock": "7.5.0",
-    "sinon": "^4.1.3"
+    "sinon": "^6.1.4"
   },
   "scripts": {
     "prepublish": "gulp prepublish",


### PR DESCRIPTION
Sinon doesn't need to be a prod dependency, the only place you use it is here: https://github.com/intercom/intercom-node/blob/4bd04979a0a0ba962d0f396fba9bf4c39f2ebefd/test/user-data.js