### PR TITLE
Support for permanently delete a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ client.users.find({ email: 'jayne@serenity.io' }, callback);
 client.users.archive({ id: '1234' }, callback);
 ```
 
+```node
+// Permanently delete a user user by id (https://developers.intercom.com/v2.0/reference#delete-users)
+const intercomUserId = '123'
+client.users.requestPermanentDeletion(intercomUserId, callback);
+```
+
 ## Leads
 
 ```node

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ client.users.find({ email: 'jayne@serenity.io' }, callback);
 ```
 
 ```node
-// Delete user by id
-client.users.delete({ id: '1234' }, callback);
+// Archive user by id (https://developers.intercom.com/v2.0/reference#archive-a-user)
+client.users.archive({ id: '1234' }, callback);
 ```
 
 ## Leads

--- a/lib/user.js
+++ b/lib/user.js
@@ -43,4 +43,7 @@ export default class User {
   bulk(params, f) {
     return (new Bulk(this.client, 'user').bulk(params, f));
   }
+  requestPermanentDeletion(intercom_user_id, f) {
+    return this.client.post('/user_delete_requests', { intercom_user_id }, f);
+  }
 }

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,10 +1,14 @@
 import Bulk from './bulk';
 import Scroll from './scroll';
+import { deprecate } from 'util';
 
 export default class User {
   constructor(client) {
     this.client = client;
     this.scroll = new Scroll(this.client, 'user');
+
+    // Keep this API around but mark it deprecated
+    this.delete = deprecate(this.archive.bind(this), 'intercom-client - user.delete: Use user.archive instead');
   }
   create(data, f) {
     return this.client.post('/users', data, f);
@@ -27,7 +31,7 @@ export default class User {
       return this.client.get(`/users`, { email: params.email }, f);
     }
   }
-  delete(params, f) {
+  archive(params, f) {
     if (params.id) {
       return this.client.delete(`/users/${params.id}`, {}, f);
     } else if (params.user_id) {

--- a/test/user.js
+++ b/test/user.js
@@ -107,4 +107,13 @@ describe('users', () => {
       done();
     });
   });
+  it('should permanently delete users by intercom user ID', done => {
+    nock('https://api.intercom.io').post('/user_delete_requests', { intercom_user_id: 'foo' }).reply(200, { id: 10 });
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.requestPermanentDeletion('foo').then(r => {
+      assert.equal(200, r.statusCode);
+      assert.deepStrictEqual({ id: 10 }, r.body);
+      done();
+    });
+  });
 });

--- a/test/user.js
+++ b/test/user.js
@@ -59,7 +59,31 @@ describe('users', () => {
       done();
     });
   });
-  it('should delete users by id', done => {
+  it('should archive users by id', done => {
+    nock('https://api.intercom.io').delete('/users/baz').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.archive({ id: 'baz' }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should archive users by user_id', done => {
+    nock('https://api.intercom.io').delete('/users').query({ user_id: 'foo' }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.archive({ user_id: 'foo' }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should archive users by email', done => {
+    nock('https://api.intercom.io').delete('/users').query({ email: 'foo' }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.archive({ email: 'foo' }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should archive (using old delete function) users by id', done => {
     nock('https://api.intercom.io').delete('/users/baz').reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.delete({ id: 'baz' }).then(r => {
@@ -67,7 +91,7 @@ describe('users', () => {
       done();
     });
   });
-  it('should delete users by user_id', done => {
+  it('should archive (using old delete function) users by user_id', done => {
     nock('https://api.intercom.io').delete('/users').query({ user_id: 'foo' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.delete({ user_id: 'foo' }).then(r => {
@@ -75,7 +99,7 @@ describe('users', () => {
       done();
     });
   });
-  it('should delete users by email', done => {
+  it('should archive (using old delete function) users by email', done => {
     nock('https://api.intercom.io').delete('/users').query({ email: 'foo' }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();
     client.users.delete({ email: 'foo' }).then(r => {


### PR DESCRIPTION
Closes #194.

Change summary:

* Renamed `users.delete` to `users.archive`
* Deprecated old `users.delete`
* Added tests for permanently deleting a user
* Implemented permanent user deletion
* Update docs