### PR TITLE
Implemented permanent delete user by params endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,20 @@ client.users.archive({ id: '1234' }, callback);
 ```
 
 ```node
-// Permanently delete a user user by id (https://developers.intercom.com/v2.0/reference#delete-users)
+// Permanently delete a user by id (https://developers.intercom.com/v2.0/reference#delete-users)
 const intercomUserId = '123'
 client.users.requestPermanentDeletion(intercomUserId, callback);
+```
+
+```node
+// Permanently delete a user by id in params
+client.users.requestPermanentDeletionByParams({ id: '55b9eaf' }, callback);
+
+// Permanently delete a user by user_id
+client.users.requestPermanentDeletionByParams({ user_id: 'foobar' }, callback);
+
+// Permanently delete a user by email
+client.users.requestPermanentDeletionByParams({ email: 'jayne@serenity.io' }, callback);
 ```
 
 ## Leads

--- a/lib/user.js
+++ b/lib/user.js
@@ -52,14 +52,8 @@ export default class User {
     }
 
     return this.find(params)
-      .then((res) => this.requestPermanentDeletion(res.body.id))
-      .then((res) => {
-        if (f) {
-          return f(null, res);
-        }
-
-        return res;
-      }).catch((err) => {
+      .then((res) => this.requestPermanentDeletion(res.body.id, f))
+      .catch((err) => {
         if (f) {
           return f(err);
         }

--- a/lib/user.js
+++ b/lib/user.js
@@ -46,4 +46,25 @@ export default class User {
   requestPermanentDeletion(intercom_user_id, f) {
     return this.client.post('/user_delete_requests', { intercom_user_id }, f);
   }
+  requestPermanentDeletionByParams(params, f) {
+    if (params.id) {
+      return this.requestPermanentDeletion(params.id, f);
+    }
+
+    return this.find(params)
+      .then((res) => this.requestPermanentDeletion(res.body.id))
+      .then((res) => {
+        if (f) {
+          return f(null, res);
+        }
+
+        return res;
+      }).catch((err) => {
+        if (f) {
+          return f(err);
+        }
+
+        throw err;
+      });
+  }
 }

--- a/test/user.js
+++ b/test/user.js
@@ -116,4 +116,65 @@ describe('users', () => {
       done();
     });
   });
+  it('should permanently delete users by Intercom user ID in params', (done) => {
+    nock('https://api.intercom.io')
+      .post('/user_delete_requests', { intercom_user_id: 'foo' })
+      .reply(200, { id: 10 });
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.requestPermanentDeletionByParams({id: 'foo'}).then((r) => {
+      assert.equal(200, r.statusCode);
+      assert.deepStrictEqual({ id: 10 }, r.body);
+      done();
+    });
+  });
+  it('should permanently delete users by user_id', (done) => {
+    nock('https://api.intercom.io')
+      .get('/users')
+      .query({ user_id: 'foo' })
+      .reply(200, { id: 10 })
+      .post('/user_delete_requests', { intercom_user_id: 10 })
+      .reply(200, { id: 10 });
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.requestPermanentDeletionByParams({user_id: 'foo'}).then((r) => {
+      assert.equal(200, r.statusCode);
+      assert.deepStrictEqual({ id: 10 }, r.body);
+      done();
+    });
+  });
+  it('should permanently delete users by email', (done) => {
+    nock('https://api.intercom.io')
+      .get('/users')
+      .query({ email: 'foo' })
+      .reply(200, { id: 10 })
+      .post('/user_delete_requests', { intercom_user_id: 10 })
+      .reply(200, { id: 10 });
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.requestPermanentDeletionByParams({email: 'foo'}).then((r) => {
+      assert.equal(200, r.statusCode);
+      assert.deepStrictEqual({ id: 10 }, r.body);
+      done();
+    });
+  });
+  it('should callback with errors if calls fail', (done) => {
+    nock('https://api.intercom.io')
+      .get('/users')
+      .query({ email: 'foo' })
+      .reply(200, {type: 'error.list'});
+    const client = new Client('foo', 'bar');
+    client.users.requestPermanentDeletionByParams({email: 'foo'}, (err) => {
+      assert.equal(true, err instanceof Error);
+      done();
+    });
+  });
+  it('should reject promises if calls fail', (done) => {
+    nock('https://api.intercom.io')
+      .get('/users')
+      .query({ email: 'foo' })
+      .reply(200, {type: 'error.list'});
+    const client = new Client('foo', 'bar').usePromises();
+    client.users.requestPermanentDeletionByParams({email: 'foo'}).catch(err => {
+      assert.equal(true, err instanceof Error);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
#### Why?

Similar to https://github.com/intercom/intercom-go/issues/44 - it's a pain to do two calls to delete a user by `user_id`.

#### How?

Uses the existing `find` and `requestPermanentDeletion` endpoints to do permanent deletion by `user_id` (or `email`).