### PR TITLE
Add binding for replying to users last conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,16 @@ var reply = {
 };
 
 client.conversations.reply(reply, callback);
+
+// Replying to users last conversation
+var reply = {
+  intercom_user_id: '55b26822ce97179e52001334',
+  body: 'Some reply :)',
+  type: "admin",
+  admin_id: "1234",
+  message_type: 'comment'
+};
+client.conversations.replyLast(reply, callback);
 ```
 
 ```node

--- a/lib/conversation.js
+++ b/lib/conversation.js
@@ -11,6 +11,9 @@ export default class Conversation {
   reply(params, f) {
     return this.client.post(`/conversations/${params.id}/reply`, params, f);
   }
+  replyLast(params, f) {
+    return this.client.post('/conversations/last/reply', params, f);
+  }
   markAsRead(params, f) {
     return this.client.put(`/conversations/${params.id}`, { read: true }, f);
   }

--- a/test/conversation.js
+++ b/test/conversation.js
@@ -27,6 +27,14 @@ describe('conversations', () => {
       done();
     });
   });
+  it('should reply last', done => {
+    nock('https://api.intercom.io').post('/conversations/last/reply', { intercom_user_id: 'bar', baz: 'bang' }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.conversations.replyLast({ intercom_user_id: 'bar', baz: 'bang' }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
   it('should mark as read', done => {
     nock('https://api.intercom.io').put('/conversations/bar', { read: true }).reply(200, {});
     const client = new Client('foo', 'bar').usePromises();


### PR DESCRIPTION
added simple method 'replyLast' for reply to users last conversation
added single testcase for testing reply last
updated README.md with sample for replyLast

#### Why?
The functionality for replying to users last conversation was missing in the nodejs bindings for the intercom api.
https://developers.intercom.com/intercom-api-reference/v1.1/reference#replying-to-users-last-conversation

#### How?
Simple addition of a function 'replyLast' in the conversation class, which calls client posts method with the '/conversations/last/reply' path and the given params
