### PR TITLE
fix(*): Upgrade natives, lodash, and remove nsp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,5 +51,5 @@ gulp.task('babel', function () {
     .pipe(gulp.dest('dist'));
 });
 
-gulp.task('prepublish', ['nsp', 'babel']);
+gulp.task('prepublish', ['babel']);
 gulp.task('default', ['static', 'test']);

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 import { deprecate } from 'util';
 import request from 'request';
 import Bluebird from 'bluebird';
-import merge from 'lodash.merge';
+import merge from 'lodash/merge';
 import User from './user';
 import Event from './event';
 import Company from './company';

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "htmlencode": "^0.0.4",
-    "lodash.merge": "^4.6.1",
+    "lodash": "^4.17.11",
     "request": "^2.83.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,11 +2688,6 @@ lodash.keysin@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.merge@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
-
 lodash.pick@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-3.1.0.tgz#f252a855b2046b61bcd3904b26f76bd2efc65550"
@@ -2746,6 +2741,11 @@ lodash@^4.0.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
   integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
+
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@~1.0.1:
   version "1.0.2"
@@ -2956,9 +2956,9 @@ nanomatch@^1.2.9:
     to-regex "^3.0.1"
 
 natives@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
-  integrity sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 nise@^1.4.5:
   version "1.4.6"


### PR DESCRIPTION
#### Why?
There's a prototype pollution vulnerability in `lodash.merge`. The recommended solution is to just use the latest version of lodash: https://github.com/lodash/lodash/issues/4171#issuecomment-457784502

Also fixed a couple of issues breaking the build:
- `nsp` has been [shut down since 9/30](https://www.npmjs.com/package/nsp). I removed it from the gulp prepublish task since it is breaking the build and throwing network errors related to a server not being reachable
- `natives` on version `1.1.3` is breaking the gulp build, upgrading it solves this. On a side note, [natives is deprecated](https://www.npmjs.com/package/natives) and should be replaced with `graceful-fs` eventually.

#### How?
Technical details on your change

- Replaced `lodash.merge` with `lodash`
- Upgraded `natives` to `1.1.6`
- Removed `nsp` from the `prepublish` gulp task