### PR TITLE
Add example of how to specify API version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ client.useRequestOpts({
 
 Note that certain request options (such as `json`, and certain `headers` names cannot be overriden).
 
+#### Setting the API version
+
+Intercom versions their API (see the "Choose Version" section of the [API & Webhooks Reference](https://developers.intercom.com/intercom-api-reference/reference) for details). You can specify which version of the API to use when performing API requests using request options:
+
+```node
+var client = new Intercom.Client({ token: 'my_token' });
+client.useRequestOpts({
+  headers: {
+    'Intercom-Version': 1.2
+  }
+});
+```
 
 ## Users
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Note that certain request options (such as `json`, and certain `headers` names c
 
 #### Setting the API version
 
-Intercom versions their API (see the "Choose Version" section of the [API & Webhooks Reference](https://developers.intercom.com/intercom-api-reference/reference) for details). You can specify which version of the API to use when performing API requests using request options:
+We version our API (see the "Choose Version" section of the [API & Webhooks Reference](https://developers.intercom.com/intercom-api-reference/reference) for details). You can specify which version of the API to use when performing API requests using request options:
 
 ```node
 var client = new Intercom.Client({ token: 'my_token' });


### PR DESCRIPTION
#### Why?
To more clearly document how to specify which API version an API call should use. It looks like this is a point of confusion (see https://github.com/intercom/intercom-node/pull/227 for an example)

#### How?
Adds an example of using API version 1.2 to the README
