### PR TITLE
Declare the responsible team as Dev Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+#### Responsible Team: Dev Platform
+
 # intercom-node
 > Official Node bindings to the Intercom API
 


### PR DESCRIPTION
Some issues with this repo were directed to Team Web (probably because of the NodeJS stuff). This will help avoid confusion in the future :)