### PR TITLE
Ap/2 10 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intercom-client",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "description": "Official Node bindings to the Intercom API",
   "homepage": "https://github.com/intercom/intercom-node",
   "bugs:": "https://github.com/intercom/intercom-node/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intercom-client",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "description": "Official Node bindings to the Intercom API",
   "homepage": "https://github.com/intercom/intercom-node",
   "bugs:": "https://github.com/intercom/intercom-node/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intercom-client",
-  "version": "2.10.7",
+  "version": "2.10.6",
   "description": "Official Node bindings to the Intercom API",
   "homepage": "https://github.com/intercom/intercom-node",
   "bugs:": "https://github.com/intercom/intercom-node/issues",


### PR DESCRIPTION
#### Why?

We were already in 2.10.5 in `npm` but the change / tag has not been applied in the repo. We need to bump to 2.10.6 for making this consistent again and be able to publish a `npm` version which match the repo one