### PR TITLE
bump stringstream from 0.0.5 to 0.0.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,9 +3504,9 @@ string_decoder@~1.0.3:
     safe-buffer "~5.1.0"
 
 stringstream@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
-  integrity sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
+  integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
 strip-ansi@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This is a secondary dependency, pulled in from [`request` version `2.83.0`](https://github.com/intercom/intercom-node/blob/39a445f731d6146e1fe6ba82dbe0d890955573ac/package.json#L24), which [requires](https://github.com/request/request/blob/dd427d7aa0177a876da69f82801bf0c63a855310/package.json#L48) `stringstream` `~0.0.5`. I updated using `yarn upgrade stringstream@~0.0.5`.

https://github.com/intercom/intercom-node/blob/39a445f731d6146e1fe6ba82dbe0d890955573ac/package.json#L24

Fixes https://github.com/intercom/intercom/issues/143632