### PR TITLE
enable updating admin away mode and reassignment settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,11 @@ client.admins.me(callback);
 client.admins.find('123456789', callback);
 ```
 
+```
+// Update admin away mode and reassign settings
+client.admins.away('123456789', {'away_mode_enabled': true, 'away_mode_reassign': false}, callback);
+```
+
 ## Tags
 
 ```node

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -11,4 +11,7 @@ export default class Admin {
   me(f) {
     return this.client.get('/me', {}, f);
   }
+  away(id, params, f) {
+    return this.client.put(`/admins/${id}/away`, params, f);
+  }
 }

--- a/test/admin.js
+++ b/test/admin.js
@@ -27,4 +27,12 @@ describe('admins', () => {
       done();
     });
   });
+  it('should update admin away mode and reassign settings', done => {
+    nock('https://api.intercom.io').put('/admins/baz/away', { away_mode_enabled: true, away_mode_reassign: false }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.admins.away('baz', { away_mode_enabled: true, away_mode_reassign: false }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
#### Why?
To enable the admin "away" endpoint 
#### How?
Added API endpoint for the "away" endpoint as documented here: https://developers.intercom.com/intercom-api-reference/reference#set-admin-away-mode