### PR TITLE
Convert Bluebird promise usage to native promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ client.users.listBy({ tag_id: 'haven' }, callback);
 client.users.scroll.each({}, function(res) {
   // if you return a promise from your callback, the client will only scroll
   // after this promise has resolved
-  new Bluebird((resolve) => {
+  new Promise((resolve) => {
     setTimeout(() => {
       console.log(res.body.users.length);
       // Your custom logic
@@ -221,7 +221,7 @@ client.leads.list(callback);
 client.leads.scroll.each({}, function(res) {
   // if you return a promise from your callback, the client will only scroll
   // after this promise has resolved
-  new Bluebird((resolve) => {
+  new Promise((resolve) => {
     setTimeout(() => {
       console.log(res.body.contacts.length);
       // Your custom logic
@@ -329,7 +329,7 @@ client.companies.listBy({ tag_id: 'haven' }, callback);
 client.companies.scroll.each({}, function(res) {
   // if you return a promise from your callback, the client will only scroll
   // after this promise has resolved
-  new Bluebird((resolve) => {
+  new Promise((resolve) => {
     setTimeout(() => {
       console.log(res.body.companies.length);
       // Your custom logic

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,5 @@
 import { deprecate } from 'util';
 import request from 'request';
-import Bluebird from 'bluebird';
 import merge from 'lodash/merge';
 import User from './user';
 import Event from './event';
@@ -65,7 +64,7 @@ export default class Client {
   promiseProxy(f, args) {
     if (this.promises || !f) {
       const callbackHandler = this.callback;
-      return new Bluebird((resolve, reject) => {
+      return new Promise((resolve, reject) => {
         const resolver = (err, data) => {
           if (err) {
             reject(err);

--- a/lib/scroll.js
+++ b/lib/scroll.js
@@ -1,5 +1,3 @@
-import Bluebird from 'bluebird';
-
 export default class Scroll {
   constructor(client, dataType) {
     this.client = client;
@@ -9,7 +7,7 @@ export default class Scroll {
     var self = this;
     this.scroll_param = undefined;
 
-    return new Bluebird(function (resolve, reject) {
+    return new Promise(function (resolve, reject) {
       self.eachInternal(params, f, { resolve, reject });
     });
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "api"
   ],
   "dependencies": {
-    "bluebird": "^3.3.4",
     "htmlencode": "^0.0.4",
     "lodash": "^4.17.15",
     "request": "^2.88.0"

--- a/test/scroll.js
+++ b/test/scroll.js
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird';
 import assert from 'assert';
 import {Client} from '../lib';
 import nock from 'nock';
@@ -59,7 +58,7 @@ describe('scroll', () => {
 
       return res.body.users.length === 0 ?
         done() :
-        new Bluebird((resolve) => {
+        new Promise((resolve) => {
           setTimeout(() => {
             assert.equal(1, nbCalls, 'hasn\'t re-scrolled before resolve');
             resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,10 +951,6 @@ binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
 
-bluebird@^3.3.4:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-
 brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"


### PR DESCRIPTION
#### Why?
This change simply converts Bluebird promise usage to native promises so that consumers can avoid including the bluebird library within their bundles.

#### How?
Replace of Bluebird -> Promise.  Bluebird can be more performant but v8 improvements have narrowed any gap for performance and performance is only going to matter in high throughput cases (i.e. totally negligible for cases with I/O latency such as this).

#### Caution
This is a breaking change for anyone that is using Bluebird specific functionality (i.e. .tap / .tapCatch / error filtering / etc)