### PR TITLE
add api 2.2 warning on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [![npm version](https://badge.fury.io/js/intercom-client.svg)](http://badge.fury.io/js/intercom-client)
 
+### Does not currently support API V2.2
+
 ## Installation
 
 [![docker_image 1](https://cloud.githubusercontent.com/assets/15954251/17524401/5743439e-5e56-11e6-8567-d3d9da1727da.png)](https://hub.docker.com/r/intercom/sdk-images/) <br>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![npm version](https://badge.fury.io/js/intercom-client.svg)](http://badge.fury.io/js/intercom-client)
 
-### Does not currently support API V2.2
+### Excluding Customer Search (2.0), only supports 1.X
 
 ## Installation
 


### PR DESCRIPTION
#### Why?
The sdk doesn't support API V2.2

#### How?
Updated the readme
