### PR TITLE
fix: contact update api

### DIFF
--- a/lib/contact.js
+++ b/lib/contact.js
@@ -16,7 +16,7 @@ export default class Contact {
     return this.client.post('/contacts', params, callback);
   }
   update(params, f) {
-    return this.client.post('/contacts', params, f);
+    return this.client.put(`/contacts/${params.id}`, params, f);
   }
   list(f) {
     return this.client.get('/contacts', {}, f);


### PR DESCRIPTION
Contact update api requires put/:id

#### Why?
Update contact api does not work. It throws error that entity exists
https://developers.intercom.com/intercom-api-reference/reference#update-contact
requires put


#### How?
fixed with proper call signature