### PR TITLE
Fix/empty npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Should exist, because dist is in .gitignore
+# More here: https://docs.npmjs.com/cli/v8/using-npm/developers#keeping-files-out-of-your-package

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "intercom-client",
-    "version": "3.0.0-1",
+    "version": "3.0.0-2",
     "description": "Official Node bindings to the Intercom API",
     "homepage": "https://github.com/intercom/intercom-node",
     "bugs:": "https://github.com/intercom/intercom-node/issues",


### PR DESCRIPTION
#### Why?
Because without `.npmignore`, `.gitignore` is fetched and `dist` folder with compiled package is ignored. Resulting in empty npm package :)

#### How?
Add empty `.npmignore`
