### PR TITLE
Simplify types to be compatible with TS v3.X

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             - run: export PATH="${PATH}:/home/circleci/.yarn/bin"
             - run: npm install --prefix=$HOME/.local --global corepack
             - run: yarn
+            - run: yarn prepublish
             - run: yarn test
 
 notify:

--- a/lib/common/common.types.ts
+++ b/lib/common/common.types.ts
@@ -24,56 +24,6 @@ export type Paginated<T> = {
     total_count: number;
 };
 
-type Join<K, P> = K extends string | number
-    ? P extends string | number
-        ? `${K}${'' extends P ? '' : '.'}${P}`
-        : never
-    : never;
-
-type Prev = [
-    never,
-    0,
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-    11,
-    12,
-    13,
-    14,
-    15,
-    16,
-    17,
-    18,
-    19,
-    20,
-    ...0[]
-];
-
-// D is depth, we don't want to go past 3 nested objects
-export type Paths<T, D extends number = 3> = [D] extends [never]
-    ? never
-    : T extends object
-    ? {
-          [K in keyof T]-?: K extends string | number
-              ? `${K}` | Join<K, Paths<T[K], Prev[D]>>
-              : never;
-      }[keyof T]
-    : '';
-
-// D is depth, we don't want to go past 3 nested objects
-export type Leaves<T, D extends number = 3> = [D] extends [never]
-    ? never
-    : T extends object
-    ? { [K in keyof T]-?: Join<K, Leaves<T[K], Prev[D]>> }[keyof T]
-    : '';
-
 export enum Operators {
     AND = 'AND',
     OR = 'OR',
@@ -89,19 +39,19 @@ export enum Operators {
     ENDS_WITH = '$',
 }
 
-interface FlatQuery<T> {
-    field: Leaves<T>;
+interface FlatQuery {
+    field: string;
     operator: Operators;
     value: string | number | null;
 }
 
-interface NestedQueries<T> {
+interface NestedQueries {
     operator: Operators;
-    value: Array<FlatQuery<T> | NestedQueries<T>> | string | number | null;
+    value: Array<FlatQuery | NestedQueries> | string | number | null;
 }
 
-export interface GenericSearchFilters<T> {
-    query: FlatQuery<T> | NestedQueries<T>;
+export interface GenericSearchFilters {
+    query: FlatQuery | NestedQueries;
 }
 
 export enum Order {

--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -3,7 +3,6 @@ import { ContactObject } from './contact/contact.types';
 import {
     GenericDeletedResponse,
     GenericSearchFilters,
-    Leaves,
     Paginated,
     Role,
 } from './common/common.types';
@@ -287,13 +286,13 @@ interface SearchContactPagination {
 
 interface SearchContactOrder {
     sort: {
-        field: Leaves<ContactObject>;
+        field: string;
         order: SearchContactOrderBy;
     };
 }
 
 interface SearchContactRequest {
-    data: GenericSearchFilters<ContactObject> &
+    data: GenericSearchFilters &
         Partial<SearchContactPagination> &
         Partial<SearchContactOrder>;
 }

--- a/lib/conversation.ts
+++ b/lib/conversation.ts
@@ -3,7 +3,6 @@ import {
     Paginated,
     StringifiedTimestamp,
     GenericSearchFilters,
-    Leaves,
     Order,
 } from './common/common.types';
 import {
@@ -499,13 +498,13 @@ interface SearchConversationPagination {
 
 interface SearchConversationOrder {
     sort: {
-        field: Leaves<ConversationObject>;
+        field: string;
         order: SearchConversationOrderBy;
     };
 }
 
 interface SearchConversationRequest {
-    data: GenericSearchFilters<ConversationObject> &
+    data: GenericSearchFilters &
         Partial<SearchConversationPagination> &
         Partial<SearchConversationOrder>;
 }


### PR DESCRIPTION
#### Why?

- To be compatible with older `TS` versions `->` `3.X`

#### How?

- By simplifying `Search` type
