### PR TITLE
Fix no email in creating contact params

### DIFF
--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -19,6 +19,7 @@ export default class Contact {
     }
     createUser({
         externalId,
+        email,
         phone,
         name,
         avatar,
@@ -31,6 +32,7 @@ export default class Contact {
         const requestData: CreateContactRequest = {
             role: Role.USER,
             external_id: externalId,
+            email,
             phone,
             name,
             avatar,
@@ -55,7 +57,7 @@ export default class Contact {
             signed_up_at: data?.signedUpAt,
             last_seen_at: data?.lastSeenAt,
             owner_id: data?.ownerId,
-            unsubscribed_from_emails: data?.isUnsubscribedFromMails,
+            unsubscribed_from_emails: data?.isUnsubscribedFromEmails,
             custom_attributes: data?.customAttributes,
         };
         return this.client.post<ContactObject>({
@@ -185,8 +187,7 @@ type CreateContactRequest = Pick<ContactObject, 'role'> &
         >
     >;
 
-interface CreateUserData {
-    externalId?: CreateContactRequest['external_id'];
+interface CreateUserDataBase {
     phone?: CreateContactRequest['phone'];
     name?: CreateContactRequest['name'];
     avatar?: CreateContactRequest['avatar'];
@@ -197,16 +198,12 @@ interface CreateUserData {
     customAttributes?: CreateContactRequest['custom_attributes'];
 }
 
-interface CreateLeadData {
-    phone?: CreateContactRequest['phone'];
-    name?: CreateContactRequest['name'];
-    avatar?: CreateContactRequest['avatar'];
-    signedUpAt?: CreateContactRequest['signed_up_at'];
-    lastSeenAt?: CreateContactRequest['last_seen_at'];
-    ownerId?: CreateContactRequest['owner_id'];
-    isUnsubscribedFromMails?: CreateContactRequest['unsubscribed_from_emails'];
-    customAttributes?: CreateContactRequest['custom_attributes'];
+interface CreateUserData extends CreateUserDataBase {
+    email?: string;
+    externalId?: string;
 }
+
+type CreateLeadData = CreateUserDataBase;
 //
 interface RetrieveContactData {
     id: string;

--- a/lib/conversation.ts
+++ b/lib/conversation.ts
@@ -406,7 +406,7 @@ interface SnoozeConversationData {
 }
 //
 export enum CloseConversationMessageType {
-    CLOSED = 'closed',
+    CLOSED = 'close',
 }
 export enum CloseConversationType {
     ADMIN = 'admin',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "intercom-client",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "description": "Official Node bindings to the Intercom API",
     "homepage": "https://github.com/intercom/intercom-node",
     "bugs:": "https://github.com/intercom/intercom-node/issues",

--- a/test/contact.ts
+++ b/test/contact.ts
@@ -5,7 +5,7 @@ import { Operators, Role } from '../lib/common/common.types';
 import { SearchContactOrderBy } from '../lib/contact';
 
 describe('contacts', () => {
-    it('should create a contact with user role', async () => {
+    it('should create a contact with user role with external id', async () => {
         const id = '536e564f316c83104c000020';
 
         const contact = {
@@ -32,6 +32,43 @@ describe('contacts', () => {
 
         const response = await client.contacts.createUser({
             externalId: contact.external_id,
+            phone: contact.phone,
+            name: contact.name,
+            avatar: contact.avatar,
+            signedUpAt: contact.signed_up_at,
+            lastSeenAt: contact.last_seen_at,
+            ownerId: contact.owner_id,
+            isUnsubscribedFromEmails: contact.unsubscribed_from_emails,
+        });
+
+        assert.deepStrictEqual(expectedReply, response);
+    });
+
+    it('should create a contact with user role with email', async () => {
+        const contact = {
+            role: 'user',
+            email: 'niko_bellic@mail.com',
+            phone: '+48370044567',
+            name: 'Niko Bellic',
+            avatar: 'https://nico-from-gta-iv.com/lets_go_bowling.jpg',
+            signed_up_at: 1638203719,
+            last_seen_at: 1638203719,
+            owner_id: 1,
+            unsubscribed_from_emails: true,
+        };
+
+        const expectedReply = {};
+
+        nock('https://api.intercom.io')
+            .post('/contacts', contact)
+            .reply(200, expectedReply);
+
+        const client = new Client({
+            usernameAuth: { username: 'foo', password: 'bar' },
+        });
+
+        const response = await client.contacts.createUser({
+            email: contact.email,
             phone: contact.phone,
             name: contact.name,
             avatar: contact.avatar,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",
-        "importHelpers": true,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "sourceMap": true,


### PR DESCRIPTION
#### Why?

To make it possible to create Contact either with `external_id` or `email`

Closes #308
Closes #309 

#### How?

- Add `email` param to `createUser`
- Fix test
