### PR TITLE
Move contribution-related topics altogether to the end of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,6 @@ yarn add intercom-client
 
 **This client is intended for server side use only. Please use the [Intercom Javascript SDK](https://developers.intercom.com/installing-intercom/docs/intercom-for-web) for client-side operations.**
 
-## Testing
-
-```bash
-yarn test
-```
-
-## Running the code locally
-
-Compile using babel:
-
-```bash
-yarn prepublish
-```
 
 ## Usage
 
@@ -1242,6 +1229,20 @@ IdentityVerification.userHash({
 ## License
 
 Apache-2.0
+
+## Testing
+
+```bash
+yarn test
+```
+
+## Running the code locally
+
+Compile using babel:
+
+```bash
+yarn prepublish
+```
 
 ## Pull Requests
 


### PR DESCRIPTION
#### Why?

For me, as a user of `intercom-node` package, when I open README.md, the first thing I need to see, is how to install and use this package.

If I ever happen to need to contribute to this package, I will probably look elsewhere; a CONTRIBUTING.md file probably.

But for now, just to make it easier for other developers to follow the usage guide, I moved it to the end of README.md, next to **Pull Requests** section

#### How?

-- Not Applicable --
