### PR TITLE
Implement the list all subscripition types functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ If you are using the european instance of intercom and would like to call it dir
 ```typescript
 const client = new Client({ tokenAuth: { token: 'my_token' } });
 client.useRequestOpts({
-    baseUrl: 'https://api.eu.intercom.io'
-})
+    baseUrl: 'https://api.eu.intercom.io',
+});
 ```
 
 ## Examples
@@ -1076,6 +1076,14 @@ const response = await client.segments.find({
 const response = await client.segments.list({
     includeCount: true,
 });
+```
+
+### Subscriptions
+
+#### [List all subscription types](https://developers.intercom.com/intercom-api-reference/reference/list-all-subscription-types)
+
+```typescript
+const response = await client.subscriptions.listTypes();
 ```
 
 ### Tags

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -13,6 +13,7 @@ import HelpCenter from './helpCenter';
 import Message from './message';
 import Note from './note';
 import Segment from './segment';
+import Subscription from './subscription';
 import Team from './team';
 import Tag from './tag';
 import Visitor from './visitor';
@@ -63,6 +64,7 @@ export default class Client {
     messages: Message;
     notes: Note;
     segments: Segment;
+    subscriptions: Subscription;
     passwordPart?: string;
     propertiesToOmitInRequestOpts: string[];
     requestOpts: Partial<AxiosDefaults>;
@@ -95,6 +97,7 @@ export default class Client {
         this.messages = new Message(this);
         this.notes = new Note(this);
         this.segments = new Segment(this);
+        this.subscriptions = new Subscription(this);
         this.tags = new Tag(this);
         this.teams = new Team(this);
         this.visitors = new Visitor(this);

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -1,0 +1,20 @@
+import { Client } from '.';
+import { SubscriptionObject } from './subscription/subscription.types';
+
+export default class Subscription {
+    public readonly baseUrl = 'subscription_types';
+
+    constructor(private readonly client: Client) {
+        this.client = client;
+    }
+    listTypes() {
+        return this.client.get<ListResponse>({
+            url: `/${this.baseUrl}`,
+        });
+    }
+}
+
+interface ListResponse {
+    type: 'list';
+    data: SubscriptionObject[];
+}

--- a/test/integration/subscriptions.test.ts
+++ b/test/integration/subscriptions.test.ts
@@ -1,0 +1,13 @@
+import { Client } from '../../dist';
+import assert from 'assert';
+import { token } from './utils/config';
+
+describe('Subscriptions', () => {
+    const client = new Client({ tokenAuth: { token } });
+
+    it('listTypes', async () => {
+        const response = await client.subscriptions.listTypes();
+
+        assert.notEqual(response, undefined);
+    });
+});

--- a/test/unit/subscription.test.ts
+++ b/test/unit/subscription.test.ts
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import { Client } from '../../lib';
+import nock from 'nock';
+
+describe('subscriptions', () => {
+    const client = new Client({
+        usernameAuth: { username: 'foo', password: 'bar' },
+    });
+
+    it('should be listed', async () => {
+        nock('https://api.intercom.io')
+            .get('/subscription_types')
+            .reply(200, { type: 'list', data: [] });
+        const response = await client.subscriptions.listTypes();
+
+        assert.deepStrictEqual({ type: 'list', data: [] }, response);
+    });
+});


### PR DESCRIPTION
#### Why?

Because I need this functionality in my application and I want to use the `intercom-node` SDK instead of accessing the API directly.

#### How?

I created `subscriptions` on the `Client` and a `listTypes` function to list all subscription types. I tried to be consistent with other parts of the client (e.g. `segments`)