### PR TITLE
Fix typo in Enum

### DIFF
--- a/lib/conversation/conversation.types.ts
+++ b/lib/conversation/conversation.types.ts
@@ -123,7 +123,7 @@ enum ConversationPriority {
 }
 
 enum ConversationSourceType {
-    CONVERASTION = 'conversation',
+    CONVERSATION = 'conversation',
     PUSH = 'push',
     FACEBOOK = 'facebook',
     TWITTER = 'twitter',


### PR DESCRIPTION
#### Why?

It's a typo

