### PR TITLE
Update conversation list to use 2.6 cursor pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Circle CI](https://circleci.com/gh/intercom/intercom-node.png?style=shield)](https://circleci.com/gh/intercom/intercom-node)
 [![npm](https://img.shields.io/npm/v/intercom-client)](https://www.npmjs.com/package/intercom-client)
-![Intercom API Version](https://img.shields.io/badge/Intercom%20API%20Version-2.5-blue)
+![Intercom API Version](https://img.shields.io/badge/Intercom%20API%20Version-2.6-blue)
 ![Typescript Supported](https://img.shields.io/badge/Typescript-Supported-lightgrey)
 
 > Official Node bindings to the [Intercom API](https://api.intercom.io/docs)
@@ -20,7 +20,6 @@ yarn add intercom-client
 ```
 
 **This client is intended for server side use only. Please use the [Intercom Javascript SDK](https://developers.intercom.com/installing-intercom/docs/intercom-for-web) for client-side operations.**
-
 
 ## Usage
 
@@ -57,7 +56,7 @@ We version our API (see the "Choose Version" section of the [API & Webhooks Refe
 const client = new Client({ tokenAuth: { token: 'my_token' } });
 client.useRequestOpts({
     headers: {
-        'Intercom-Version': 2.4,
+        'Intercom-Version': 2.6,
     },
 });
 ```
@@ -725,9 +724,7 @@ const response = await client.conversations.search({
 
 ```typescript
 const response = await client.conversations.list({
-    order: Order.DESC,
-    sort: SortBy.UpdatedAt,
-    page: 1,
+    startingAfter: 'WzE2NzA0MjI1MjkwMDAsMjQzMTY3NzA2ODcsMl0=',
     perPage: 10,
 });
 ```
@@ -1088,7 +1085,6 @@ const response = await client.segments.list({
 });
 ```
 
-
 ### Subscriptions
 
 #### [List all subscription types](https://developers.intercom.com/intercom-api-reference/reference/list-all-subscription-types)
@@ -1096,6 +1092,7 @@ const response = await client.segments.list({
 ```typescript
 const response = await client.subscriptions.listTypes();
 ```
+
 ### PhoneCallRedirects
 
 #### [Create a phone call redirect](https://developers.intercom.com/intercom-api-reference/reference/create-a-phone-switch)

--- a/lib/contact/contact.types.ts
+++ b/lib/contact/contact.types.ts
@@ -45,6 +45,8 @@ export interface ContactObject {
     tags: AddressableList;
     notes: AddressableList;
     companies: AddressableList;
+    opted_in_subscription_types: AddressableList;
+    opted_out_subscription_tyes: AddressableList;
     referrer: string;
     utm_campaign: string | null;
     utm_content: string | null;

--- a/lib/conversation.ts
+++ b/lib/conversation.ts
@@ -2,7 +2,6 @@ import Client from './client';
 import {
     StringifiedTimestamp,
     GenericSearchFilters,
-    Order,
     PaginatedBase,
 } from './common/common.types';
 import {
@@ -256,8 +255,11 @@ export default class Conversation {
             data,
         });
     }
-    list({ order, sort, page, perPage: per_page }: ListConversationData) {
-        const params = { order, sort, page, per_page };
+    list({
+        startingAfter: starting_after,
+        perPage: per_page,
+    }: ListConversationData) {
+        const params = { starting_after, per_page };
 
         return this.client.get<ListConversationResponse>({
             url: `/${this.baseUrl}`,
@@ -518,9 +520,7 @@ export enum SortBy {
 }
 
 interface ListConversationData {
-    order?: Order;
-    sort?: SortBy;
-    page?: number;
+    startingAfter?: string;
     perPage?: number;
 }
 

--- a/test/unit/conversation.test.ts
+++ b/test/unit/conversation.test.ts
@@ -12,9 +12,8 @@ import {
     ReplyToConversationUserType,
     SearchConversationOrderBy,
     SnoozeConversationMessageType,
-    SortBy,
 } from '../../lib/conversation';
-import { Operators, Order } from '../../lib/common/common.types';
+import { Operators } from '../../lib/common/common.types';
 
 describe('conversations', () => {
     it('should create a conversation', async () => {
@@ -545,11 +544,27 @@ describe('conversations', () => {
         assert.deepStrictEqual(expectedReply, response);
     });
 
-    it('should list all conversations', async () => {
+    it('should list all conversations with', async () => {
         const expectedReply = {};
 
         nock('https://api.intercom.io')
-            .get(`/conversations?order=desc&sort=updated_at&page=1&per_page=10`)
+            .get(`/conversations`)
+            .reply(200, expectedReply);
+
+        const client = new Client({
+            usernameAuth: { username: 'foo', password: 'bar' },
+        });
+
+        const response = await client.conversations.list({});
+
+        assert.deepStrictEqual(expectedReply, response);
+    });
+
+    it('should list all conversations with per_page param', async () => {
+        const expectedReply = {};
+
+        nock('https://api.intercom.io')
+            .get(`/conversations?per_page=10`)
             .reply(200, expectedReply);
 
         const client = new Client({
@@ -557,9 +572,25 @@ describe('conversations', () => {
         });
 
         const response = await client.conversations.list({
-            order: Order.DESC,
-            sort: SortBy.UpdatedAt,
-            page: 1,
+            perPage: 10,
+        });
+
+        assert.deepStrictEqual(expectedReply, response);
+    });
+
+    it('should list all conversations with starting_after', async () => {
+        const expectedReply = {};
+
+        nock('https://api.intercom.io')
+            .get(`/conversations?starting_after=asdf123&per_page=10`)
+            .reply(200, expectedReply);
+
+        const client = new Client({
+            usernameAuth: { username: 'foo', password: 'bar' },
+        });
+
+        const response = await client.conversations.list({
+            startingAfter: 'asdf123',
             perPage: 10,
         });
 


### PR DESCRIPTION
#### Why?

```
Promise { <pending> }
> {
  type: 'conversation.list',
  pages: {
    type: 'pages',
    next: {
      page: 3,
      starting_after: 'WzE2NzAyNTE1ODAwMDAsNjQ2MTk3MDAwMDU2MDYsM10='
    },
    page: 2,
    per_page: 20,
    total_pages: 86
  },
```