### PR TITLE
Fix typo in Recepient and RecepientType

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -57,7 +57,7 @@ export {
     SortBy,
     RedactConversationPartType,
 } from './conversation';
-export { RecepientType } from './message';
+export { RecipientType } from './message';
 export {
     ContactObjectForMerge,
     MergeVisitorToContactData,

--- a/lib/message.ts
+++ b/lib/message.ts
@@ -38,8 +38,8 @@ export default class Message {
 interface CreateMessageRequest {
     message_type: MessageType;
     body: string;
-    from: Recepient;
-    to: Recepient;
+    from: Recipient;
+    to: Recipient;
     subject?: string;
     template?: string;
     create_conversation_without_contact_reply?: boolean;
@@ -54,12 +54,12 @@ interface CreateMessageBody
     createConversationWithoutContactReply?: boolean;
 }
 
-type Recepient = {
+type Recipient = {
     id: string;
-    type: RecepientType;
+    type: RecipientType;
 };
 
-export enum RecepientType {
+export enum RecipientType {
     ADMIN = 'admin',
     USER = 'user',
     LEAD = 'lead',

--- a/test/integration/messages.test.ts
+++ b/test/integration/messages.test.ts
@@ -2,7 +2,7 @@ import { token } from './utils/config';
 import { Client, Operators } from '../../dist';
 import { randomString } from './utils/random';
 import { MessageType } from '../../lib/message/message.types';
-import { RecepientType } from '../../lib/message';
+import { RecipientType } from '../../lib/message';
 import assert from 'assert';
 
 describe('Messages', () => {
@@ -28,11 +28,11 @@ describe('Messages', () => {
             message_type: MessageType.INAPP,
             body: 'Hey, look at me! I am the conversations creator now!',
             from: {
-                type: RecepientType.ADMIN,
+                type: RecipientType.ADMIN,
                 id: adminId,
             },
             to: {
-                type: RecepientType.USER,
+                type: RecipientType.USER,
                 id: userIntercomId,
             },
         };
@@ -66,11 +66,11 @@ describe('Messages', () => {
             message_type: MessageType.INAPP,
             body: 'Message without creating conversation',
             from: {
-                type: RecepientType.ADMIN,
+                type: RecipientType.ADMIN,
                 id: adminId,
             },
             to: {
-                type: RecepientType.USER,
+                type: RecipientType.USER,
                 id: userIntercomId,
             },
         };

--- a/test/unit/message.test.ts
+++ b/test/unit/message.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { Client } from '../../lib';
 import nock from 'nock';
 import { MessageType } from '../../lib/message/message.types';
-import { RecepientType } from '../../lib/message';
+import { RecipientType } from '../../lib/message';
 
 describe('messages', () => {
     it('should be created', async () => {
@@ -12,11 +12,11 @@ describe('messages', () => {
             body: 'Destroy ponies',
             template: 'plain',
             from: {
-                type: RecepientType.ADMIN,
+                type: RecipientType.ADMIN,
                 id: '394051',
             },
             to: {
-                type: RecepientType.USER,
+                type: RecipientType.USER,
                 id: '536e564f316c83104c000020',
             },
         };


### PR DESCRIPTION
Updates spelling from Recepient to Recipient

closes #352

#### Why?

Fixes a typo

#### How?

Renaming of some types. Should be considered a **Breaking Change**
