### PR TITLE
Update create conversations endpoint with 2.6 typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Breaking changes
 
-The Node SDK has been updated to support latest API version (2.5). The update also contains requested features, such like Typescript support. You can find more information on how-to migrate and what has changed in the [migration guide](https://github.com/intercom/intercom-node/wiki/Migration-guide).
+The Node SDK has been updated to support latest API version (2.6). The update also contains requested features, such like Typescript support. You can find more information on how-to migrate and what has changed in the [migration guide](https://github.com/intercom/intercom-node/wiki/Migration-guide).
 
 ## Installation
 

--- a/lib/conversation.ts
+++ b/lib/conversation.ts
@@ -17,11 +17,11 @@ export default class Conversation {
     constructor(private readonly client: Client) {
         this.client = client;
     }
-    create({ userId, body }: CreateConversationData) {
+    create({ userId, type = ContactType.USER, body }: CreateConversationData) {
         const requestData: CreateConversationRequest = {
             from: {
                 id: userId,
-                type: 'user',
+                type,
             },
             body,
         };
@@ -288,7 +288,7 @@ export default class Conversation {
 
 interface CreateConversationRequest {
     from: {
-        type: 'user' | string;
+        type: ContactType;
         id: string;
     };
     body: string;
@@ -296,6 +296,7 @@ interface CreateConversationRequest {
 
 interface CreateConversationData {
     userId: string;
+    type?: ContactType;
     body: string;
 }
 //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "intercom-client",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "Official Node bindings to the Intercom API",
     "homepage": "https://github.com/intercom/intercom-node",
     "bugs:": "https://github.com/intercom/intercom-node/issues",

--- a/test/integration/conversations.test.ts
+++ b/test/integration/conversations.test.ts
@@ -7,6 +7,7 @@ import {
     ContactObject,
     ConversationObject,
     MessageObject,
+    ContactType,
 } from '../../lib';
 import assert from 'assert';
 import { token } from './utils/config';
@@ -15,6 +16,7 @@ import { randomString } from './utils/random';
 describe('Conversations', () => {
     let user: ContactObject;
     let secondUser: ContactObject;
+    let leadUser: ContactObject;
     let createdConversation: MessageObject;
     let foundConversation: ConversationObject;
 
@@ -38,15 +40,41 @@ describe('Conversations', () => {
             name: 'Babushka Boy',
             email: 'babushka_boy@bababooey.com',
         });
+        leadUser = await client.contacts.createLead({
+            name: 'Babushka Lead',
+            email: 'babushka_lead@bababooey.com',
+        });
     });
 
-    it('create', async () => {
+    it('create conversation with user as default', async () => {
         const response = await client.conversations.create({
             userId: user.id,
             body: 'Raz-dwa-try kalyna, czorniawaja diwczyna',
         });
 
         createdConversation = response;
+
+        assert.notEqual(response, undefined);
+    });
+
+    it('create conversation with user', async () => {
+        const response = await client.conversations.create({
+            userId: user.id,
+            body: 'Raz-dwa-try kalyna, czorniawaja diwczyna',
+            type: ContactType.USER,
+        });
+
+        createdConversation = response;
+
+        assert.notEqual(response, undefined);
+    });
+
+    it('create conversation with lead', async () => {
+        const response = await client.conversations.create({
+            userId: leadUser.id,
+            body: 'Raz-dwa-try kalyna, czorniawaja diwczyna',
+            type: ContactType.LEAD,
+        });
 
         assert.notEqual(response, undefined);
     });

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -1,4 +1,4 @@
-import { Client, ContactObject, MessageObject } from '../../lib';
+import { Client, ContactObject, ContactType, MessageObject } from '../../lib';
 import assert from 'assert';
 import { token } from './utils/config';
 import { randomInt } from 'crypto';
@@ -66,6 +66,7 @@ describe('Integration between Contact, Conversation, Company and Tag APIs', () =
         const response = await client.conversations.create({
             userId: contact.id,
             body: 'Welcome to the club, buddy!',
+            type: ContactType.USER,
         });
 
         conversation = response;

--- a/test/unit/conversation.test.ts
+++ b/test/unit/conversation.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { Client } from '../../lib';
+import { Client, ContactType } from '../../lib';
 import nock from 'nock';
 import {
     AssignToConversationMessageType,
@@ -16,7 +16,7 @@ import {
 import { Operators } from '../../lib/common/common.types';
 
 describe('conversations', () => {
-    it('should create a conversation', async () => {
+    it('should create a conversation from a user', async () => {
         const id = '536e564f316c83104c000020';
 
         const message = {
@@ -46,6 +46,44 @@ describe('conversations', () => {
 
         const response = await client.conversations.create({
             userId: id,
+            type: ContactType.USER,
+            body: message.body,
+        });
+
+        assert.deepStrictEqual(expectedReply, response);
+    });
+
+    it('should create a conversation from a lead', async () => {
+        const id = '536e564f316c83104c000020';
+
+        const message = {
+            from: {
+                type: 'lead',
+                id,
+            },
+            body: 'Hello darkness my old friend',
+        };
+
+        const expectedReply = {
+            type: 'user_message',
+            id: '2001',
+            created_at: 1401917202,
+            body: 'Hello darkness my old friend',
+            message_type: 'inapp',
+            conversation_id: '36000324324',
+        };
+
+        nock('https://api.intercom.io')
+            .post('/conversations', message)
+            .reply(200, expectedReply);
+
+        const client = new Client({
+            usernameAuth: { username: 'foo', password: 'bar' },
+        });
+
+        const response = await client.conversations.create({
+            userId: id,
+            type: ContactType.LEAD,
             body: message.body,
         });
 


### PR DESCRIPTION
#### Why?

Add typings to [reflect field change in 2.6](https://developers.intercom.com/intercom-api-reference/v2.6/reference/changelog#create-conversation-payload-consistency) 

#### How?

Added a `type` argument to the `conversations.create` method, with a default that matched the existing behaviour so as not to break existing implementations