### PR TITLE
Fix ListAttachedTagsResponse type

### DIFF
--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -315,7 +315,7 @@ type ListContactsResponse = Paginated<ContactObject>;
 //
 type ListAttachedTagsResponse = {
     type: string;
-    tags: Array<TagObject>;
+    data: Array<TagObject>;
 };
 //
 type ListAttachedSegmentsResponse = {


### PR DESCRIPTION
#### Why?
The type has the `tags` key but the response when the client is used has the `data` key instead

#### How?

Fixes this type so it correctly reflects what is returned by the Intercom API.
