### PR TITLE
feat(tags): tagContacts feature implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,12 +1129,21 @@ const response = await client.tags.update({ id: '123', name: 'haven' });
 const response = await client.tags.delete({ id: 'baz' });
 ```
 
-#### [Attach a contact](https://developers.intercom.com/intercom-api-reference/reference/tag-contact)
+#### [Tag one contact](https://developers.intercom.com/intercom-api-reference/reference/tag-contact)
 
 ```typescript
 const response = await client.tags.tagContact({
     contactId: '123',
     tagId: '234',
+});
+```
+
+#### [Tag multiple contacts](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tags/createTag/)
+
+```typescript
+const response = await client.tags.tagContacts({
+    tagName: 'gutenTag',
+    usersIds: ['123', '234', '456'],
 });
 ```
 

--- a/lib/tag.ts
+++ b/lib/tag.ts
@@ -34,10 +34,10 @@ export default class Tag {
             data,
         });
     }
-    tagContacts({ tagName: name, usersIds }: TagContactsData) {
+    tagContacts({ tagName: name, contactsIds }: TagContactsData) {
         const data = {
             name,
-            users: usersIds.map((id) => ({ id: id })),
+            users: contactsIds.map((id) => ({ id: id })),
         };
 
         return this.client.post<TagObject>({
@@ -127,7 +127,7 @@ interface TagContactData {
 }
 interface TagContactsData {
     tagName: string;
-    usersIds: string[];
+    contactsIds: string[];
 }
 //
 interface TagConversationData {

--- a/lib/tag.ts
+++ b/lib/tag.ts
@@ -34,6 +34,17 @@ export default class Tag {
             data,
         });
     }
+    tagContacts({ tagName: name, usersIds }: TagContactsData) {
+        const data = {
+            name,
+            users: usersIds.map((id) => ({ id: id })),
+        };
+
+        return this.client.post<TagObject>({
+            url: `/${this.tagsBaseUrl}`,
+            data,
+        });
+    }
     tagConversation({
         conversationId,
         tagId,
@@ -113,6 +124,10 @@ interface DeleteTagData {
 interface TagContactData {
     contactId: string;
     tagId: string;
+}
+interface TagContactsData {
+    tagName: string;
+    usersIds: string[];
 }
 //
 interface TagConversationData {

--- a/test/integration/tags.test.ts
+++ b/test/integration/tags.test.ts
@@ -54,7 +54,7 @@ describe('Tags', () => {
     it('tagContacts', async () => {
         const response = await client.tags.tagContacts({
             tagName: 'Poor',
-            usersIds: [contactId],
+            contactsIds: [contactId],
         });
 
         assert.notEqual(response, undefined);

--- a/test/integration/tags.test.ts
+++ b/test/integration/tags.test.ts
@@ -51,6 +51,14 @@ describe('Tags', () => {
 
         assert.notEqual(response, undefined);
     });
+    it('tagContacts', async () => {
+        const response = await client.tags.tagContacts({
+            tagName: 'Poor',
+            usersIds: [contactId],
+        });
+
+        assert.notEqual(response, undefined);
+    });
     it('tagConversation', async () => {
         const response = await client.tags.tagConversation({
             conversationId,

--- a/test/unit/tag.test.ts
+++ b/test/unit/tag.test.ts
@@ -44,7 +44,7 @@ describe('tags', () => {
 
         assert.deepStrictEqual({}, response);
     });
-    it('should tag contacts', async () => {
+    it('should tag contact', async () => {
         const contactId = 'contactid123';
         const requestBody = {
             id: 'tagid123',
@@ -59,6 +59,25 @@ describe('tags', () => {
         const response = await client.tags.tagContact({
             contactId,
             tagId: requestBody.id,
+        });
+
+        assert.deepStrictEqual({}, response);
+    });
+    it('should tag contacts', async () => {
+        const requestBody = {
+            name: 'tagname_69',
+            users: [{ id: '123' }, { id: '234' }, { id: '456' }],
+        };
+
+        nock('https://api.intercom.io')
+            .post(`/tags`, requestBody)
+            .reply(200, {});
+        const client = new Client({
+            usernameAuth: { username: 'foo', password: 'bar' },
+        });
+        const response = await client.tags.tagContacts({
+            tagName: requestBody.name,
+            usersIds: ['123', '234', '456'],
         });
 
         assert.deepStrictEqual({}, response);

--- a/test/unit/tag.test.ts
+++ b/test/unit/tag.test.ts
@@ -77,7 +77,7 @@ describe('tags', () => {
         });
         const response = await client.tags.tagContacts({
             tagName: requestBody.name,
-            usersIds: ['123', '234', '456'],
+            contactsIds: ['123', '234', '456'],
         });
 
         assert.deepStrictEqual({}, response);


### PR DESCRIPTION
#### Why?

The Intercom API exposes a method where we can tag multiple users at once using the tag name. At the moment, this SDK only offers the possibility to tag users one by one using the tag ID.

More information about the API method [here](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tags/createTag/).

#### How?

The implementation of this method is the same as `tagCompanies`. The only difference is that instead of passing an array of strings called `companies`, you need to pass an array of strings called `users`.

The necessary test cases were added (both unit tests and integration tests). Additionally, the documentation was updated.