### PR TITLE
Add `TagObject` interface

### DIFF
--- a/lib/conversation/conversation.types.ts
+++ b/lib/conversation/conversation.types.ts
@@ -1,5 +1,6 @@
 import { AdminObject } from '../admin/admin.types';
 import { JavascriptObject, Seconds, Timestamp } from '../common/common.types';
+import { TagListObject } from '../tag/tag.types';
 
 export interface ConversationObject {
     type: 'conversation';
@@ -19,7 +20,7 @@ export interface ConversationObject {
     read: boolean;
     waiting_since: Timestamp;
     snoozed_until: Timestamp;
-    tags: JavascriptObject[];
+    tags: TagListObject[];
     first_contact_reply: FirstContactReplyObject;
     priority: ConversationPriority;
     sla_applied: SLAObject;

--- a/lib/tag/tag.types.ts
+++ b/lib/tag/tag.types.ts
@@ -3,3 +3,14 @@ export interface TagObject {
     name: string;
     type: 'tag';
 }
+
+export interface TagListObject {
+    tags: (TagObject & {
+        applied_at: string;
+        applied_by: {
+            id?: string;
+            type: string;
+        };
+    })[];
+    type: 'tag.list';
+}


### PR DESCRIPTION
#### Why?

Replaced the loosely-typed array of JavaScript objects with a structured `TagObject` in the conversation model to match the documented shape of the response
The typing is based on the official response documentation [here](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Conversations/retrieveConversation/#!t=response&c=200&path=tags) 

#### How?

Adds a new interface in `tag.types` called `TagListObject` which is used by `ConversationObject`