### PR TITLE
Wrong request URL when conversation is assigned with "withRunningAssignmentRules" parameter

### DIFF
--- a/lib/conversation.ts
+++ b/lib/conversation.ts
@@ -142,8 +142,7 @@ export default class Conversation {
         withRunningAssignmentRules = false,
     }: AssignConversationData) {
         const url = `/${this.baseUrl}/${id}${
-            withRunningAssignmentRules ? '/run_assignment_rules' : ''
-        }/parts`;
+            withRunningAssignmentRules ? '/run_assignment_rules' : '/parts'}`;
         const data: AssignConversationRequest | undefined =
             withRunningAssignmentRules
                 ? undefined

--- a/test/unit/conversation.test.ts
+++ b/test/unit/conversation.test.ts
@@ -321,7 +321,7 @@ describe('conversations', () => {
         const expectedReply = {};
 
         nock('https://api.intercom.io')
-            .post(`/conversations/${id}/run_assignment_rules/parts`)
+            .post(`/conversations/${id}/run_assignment_rules`)
             .reply(200, expectedReply);
 
         const client = new Client({


### PR DESCRIPTION
#### Why?

The **withRunningAssignmentRules** parameter is supposed to append `/run_assignment_rules` to the URL but instead it appends `/run_assignment_rules/parts`. The API is throwing the 404 error when you attempt to send a request to this URL.

Intercom API doc article for the reference: https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Conversations/autoAssignConversation/

#### How?

In original code, the `/parts` string is being appended to the URL no matter the value of **withRunningAssignmentRules** variable. I moved the `/parts` string into the ternary expression so now it's appended only when **withRunningAssignmentRules** is false or undefined.