### PR TITLE
Update company retrieve to match http api

### DIFF
--- a/src/api/resources/companies/client/Client.ts
+++ b/src/api/resources/companies/client/Client.ts
@@ -103,7 +103,7 @@ export class Companies {
     public async retrieve(
         request: Intercom.RetrieveCompanyRequest = {},
         requestOptions?: Companies.RequestOptions
-    ): Promise<Intercom.CompanyList> {
+    ): Promise<Intercom.CompanyList | Intercom.Company> {
         const { name, company_id: companyId, tag_id: tagId, segment_id: segmentId, page, per_page: perPage } = request;
         const _queryParams: Record<string, string | string[] | object | object[]> = {};
         if (name != null) {
@@ -155,6 +155,9 @@ export class Companies {
             abortSignal: requestOptions?.abortSignal,
         });
         if (_response.ok) {
+            if (name != null || companyId != null) {
+                return _response.body as Intercom.Company;
+            }
             return _response.body as Intercom.CompanyList;
         }
 


### PR DESCRIPTION
#### Why?

Why are you making this change?

Company retrieve doesn't match the api [here](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/companies/retrievecompany) which can return either a Company or a Company list depending on whether the company_id or name param are specified.

#### How?

Technical details on your change

Changed the output of retrieve to return either Company or CompanyList. Added an or to check which parameters were passed and return the correct type.
