### PR TITLE
Fix pagination test for conversations with API v2.14

### DIFF
--- a/tests/integration/pagination.test.ts
+++ b/tests/integration/pagination.test.ts
@@ -49,6 +49,23 @@ describe("Pagination", () => {
             limit: 2,
             perPage: 1,
             greaterThan: 1,
+            async setup() {
+                const contact = await client.contacts.create({
+                    external_id: randomString(),
+                });
+
+                await client.conversations.create({
+                    from: { id: contact.id, type: "user" },
+                    body: "Test conversation 1",
+                });
+
+                await client.conversations.create({
+                    from: { id: contact.id, type: "user" },
+                    body: "Test conversation 2",
+                });
+
+                return {};
+            },
         },
         {
             name: "notes",


### PR DESCRIPTION
#### Why?

  The v7.0.0 release failed to publish to npm because the pagination test for conversations was failing in CI.

  The test was relying on pre-existing conversations in the test account, but when the default Intercom API version was upgraded from 2.11 to 2.14 in v7.0.0, API v2.14 returns fewer conversations (only 1 instead of the expected 2+). This caused the assertion `expect(pagerCount).toBeGreaterThan(1)` to fail.

  This needs to be fixed so we can successfully publish v7.0.0 to npm.

  #### How?

  Added a `setup` function to the conversations pagination test case that creates its own test data:
  - Creates a test contact
  - Creates 2 test conversations using that contact
  - Returns an empty object for the test parameters

  This makes the test self-contained and reliable regardless of the API version or existing data in the test account, matching the pattern already used by the "notes" pagination test case.