### PR TITLE
Bump version to 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "intercom-client",
-    "version": "7.0.0",
+    "version": "7.0.1",
     "private": false,
     "repository": "github:intercom/intercom-node",
     "type": "commonjs",


### PR DESCRIPTION
#### Why?

  v7.0.0 failed to publish to npm due to a failing test. Bumping to v7.0.1 to retry after the test fix.

  #### How?

  Updated version in package.json from 7.0.0 to 7.0.1.